### PR TITLE
Add alternative locations for some checks

### DIFF
--- a/clomonitor-core/src/linter/patterns.rs
+++ b/clomonitor-core/src/linter/patterns.rs
@@ -1,10 +1,14 @@
 // Documentation
-pub(crate) static ADOPTERS: [&str; 1] = ["adopters*"];
-pub(crate) static CODE_OF_CONDUCT: [&str; 2] = ["code*of*conduct.md", "docs/code*of*conduct.md"];
-pub(crate) static CONTRIBUTING: [&str; 2] = ["contributing*", "docs/contributing*"];
-pub(crate) static CHANGELOG: [&str; 1] = ["changelog*"];
-pub(crate) static GOVERNANCE: [&str; 2] = ["governance*", "docs/governance*"];
-pub(crate) static MAINTAINERS: [&str; 7] = [
+pub(crate) static ADOPTERS_FILE: [&str; 1] = ["adopters*"];
+pub(crate) static ADOPTERS_HEADER: [&str; 1] = [r"(?im)^#+.*adopters.*$"];
+pub(crate) static CODE_OF_CONDUCT_FILE: [&str; 2] =
+    ["code*of*conduct.md", "docs/code*of*conduct.md"];
+pub(crate) static CODE_OF_CONDUCT_HEADER: [&str; 1] = [r"(?im)^#+.*code of conduct.*$"];
+pub(crate) static CONTRIBUTING_FILE: [&str; 2] = ["contributing*", "docs/contributing*"];
+pub(crate) static CHANGELOG_FILE: [&str; 1] = ["changelog*"];
+pub(crate) static GOVERNANCE_FILE: [&str; 2] = ["governance*", "docs/governance*"];
+pub(crate) static GOVERNANCE_HEADER: [&str; 1] = [r"(?im)^#+.*governance.*$"];
+pub(crate) static MAINTAINERS_FILE: [&str; 7] = [
     "maintainers*",
     "docs/maintainers*",
     "owners*",
@@ -13,22 +17,26 @@ pub(crate) static MAINTAINERS: [&str; 7] = [
     "docs/codeowners*",
     ".github/codeowners*",
 ];
-pub(crate) static README: [&str; 1] = ["README*"];
-pub(crate) static ROADMAP: [&str; 1] = ["roadmap*"];
+pub(crate) static README_FILE: [&str; 1] = ["README*"];
+pub(crate) static ROADMAP_FILE: [&str; 1] = ["roadmap*"];
+pub(crate) static ROADMAP_HEADER: [&str; 1] = [r"(?im)^#+.*roadmap.*$"];
 
 // License
-pub(crate) static LICENSE: [&str; 2] = ["LICENSE*", "COPYING*"];
-pub(crate) static FOSSA_BADGE: [&str; 1] = [r"https://app.fossa.*/api/projects/.*"];
+pub(crate) static LICENSE_FILE: [&str; 2] = ["LICENSE*", "COPYING*"];
+pub(crate) static FOSSA_BADGE_URL: [&str; 1] = [r"https://app.fossa.*/api/projects/.*"];
 
 // Best practices
-pub(crate) static ARTIFACTHUB_BADGE: [&str; 1] = [r"https://artifacthub.io/badge/repository/.*"];
-pub(crate) static COMMUNITY_MEETING: [&str; 3] = [
+pub(crate) static ARTIFACTHUB_BADGE_URL: [&str; 1] =
+    [r"https://artifacthub.io/badge/repository/.*"];
+pub(crate) static COMMUNITY_MEETING_TEXT: [&str; 3] = [
     r"(?i)(community|developer|development) (call|event|meeting|session)",
     r"(?i)(weekly|biweekly|monthly) meeting",
     r"(?i)meeting minutes",
 ];
-pub(crate) static OPENSSF_BADGE: [&str; 1] =
+pub(crate) static OPENSSF_BADGE_URL: [&str; 1] =
     [r"https://bestpractices.coreinfrastructure.org/projects/\d+"];
 
 // Security
-pub(crate) static SECURITY_POLICY: [&str; 3] = ["security*", "docs/security*", ".github/security*"];
+pub(crate) static SECURITY_POLICY_FILE: [&str; 3] =
+    ["security*", "docs/security*", ".github/security*"];
+pub(crate) static SECURITY_POLICY_HEADER: [&str; 1] = [r"(?im)^#+.*security.*$"];

--- a/clomonitor-core/src/linter/primary.rs
+++ b/clomonitor-core/src/linter/primary.rs
@@ -72,44 +72,72 @@ async fn lint_documentation(root: &Path, repo_url: &str) -> Result<Documentation
     Ok(Documentation {
         adopters: check::path_exists(Globs {
             root,
-            patterns: ADOPTERS,
+            patterns: ADOPTERS_FILE,
             case_sensitive: false,
-        })?,
+        })? || check::content_matches(
+            Globs {
+                root,
+                patterns: README_FILE,
+                case_sensitive: true,
+            },
+            ADOPTERS_HEADER,
+        )?,
         code_of_conduct: check::path_exists(Globs {
             root,
-            patterns: CODE_OF_CONDUCT,
+            patterns: CODE_OF_CONDUCT_FILE,
             case_sensitive: false,
-        })?,
+        })? || check::content_matches(
+            Globs {
+                root,
+                patterns: README_FILE,
+                case_sensitive: true,
+            },
+            CODE_OF_CONDUCT_HEADER,
+        )?,
         contributing: check::path_exists(Globs {
             root,
-            patterns: CONTRIBUTING,
+            patterns: CONTRIBUTING_FILE,
             case_sensitive: false,
         })?,
         changelog: check::path_exists(Globs {
             root,
-            patterns: CHANGELOG,
+            patterns: CHANGELOG_FILE,
             case_sensitive: false,
         })?,
         governance: check::path_exists(Globs {
             root,
-            patterns: GOVERNANCE,
+            patterns: GOVERNANCE_FILE,
             case_sensitive: false,
-        })?,
+        })? || check::content_matches(
+            Globs {
+                root,
+                patterns: README_FILE,
+                case_sensitive: true,
+            },
+            GOVERNANCE_HEADER,
+        )?,
         maintainers: check::path_exists(Globs {
             root,
-            patterns: MAINTAINERS,
+            patterns: MAINTAINERS_FILE,
             case_sensitive: false,
         })?,
         readme: check::path_exists(Globs {
             root,
-            patterns: README,
+            patterns: README_FILE,
             case_sensitive: true,
         })?,
         roadmap: check::path_exists(Globs {
             root,
-            patterns: ROADMAP,
+            patterns: ROADMAP_FILE,
             case_sensitive: false,
-        })?,
+        })? || check::content_matches(
+            Globs {
+                root,
+                patterns: README_FILE,
+                case_sensitive: true,
+            },
+            ROADMAP_HEADER,
+        )?,
         website: check::has_website(repo_url).await,
     })
 }
@@ -118,7 +146,7 @@ async fn lint_documentation(root: &Path, repo_url: &str) -> Result<Documentation
 fn lint_license(root: &Path) -> Result<License, Error> {
     let spdx_id = check::license(Globs {
         root,
-        patterns: LICENSE,
+        patterns: LICENSE_FILE,
         case_sensitive: true,
     })?;
 
@@ -132,10 +160,10 @@ fn lint_license(root: &Path) -> Result<License, Error> {
         fossa_badge: check::content_matches(
             Globs {
                 root,
-                patterns: README,
+                patterns: README_FILE,
                 case_sensitive: true,
             },
-            FOSSA_BADGE,
+            FOSSA_BADGE_URL,
         )?,
         spdx_id,
     })
@@ -147,26 +175,26 @@ fn lint_best_practices(root: &Path) -> Result<BestPractices, Error> {
         artifacthub_badge: check::content_matches(
             Globs {
                 root,
-                patterns: README,
+                patterns: README_FILE,
                 case_sensitive: true,
             },
-            ARTIFACTHUB_BADGE,
+            ARTIFACTHUB_BADGE_URL,
         )?,
         community_meeting: check::content_matches(
             Globs {
                 root,
-                patterns: README,
+                patterns: README_FILE,
                 case_sensitive: true,
             },
-            COMMUNITY_MEETING,
+            COMMUNITY_MEETING_TEXT,
         )?,
         openssf_badge: check::content_matches(
             Globs {
                 root,
-                patterns: README,
+                patterns: README_FILE,
                 case_sensitive: true,
             },
-            OPENSSF_BADGE,
+            OPENSSF_BADGE_URL,
         )?,
     })
 }
@@ -176,8 +204,15 @@ fn lint_security(root: &Path) -> Result<Security, Error> {
     Ok(Security {
         security_policy: check::path_exists(Globs {
             root,
-            patterns: SECURITY_POLICY,
+            patterns: SECURITY_POLICY_FILE,
             case_sensitive: false,
-        })?,
+        })? || check::content_matches(
+            Globs {
+                root,
+                patterns: README_FILE,
+                case_sensitive: true,
+            },
+            SECURITY_POLICY_HEADER,
+        )?,
     })
 }

--- a/clomonitor-core/src/linter/secondary.rs
+++ b/clomonitor-core/src/linter/secondary.rs
@@ -45,17 +45,17 @@ fn lint_documentation(root: &Path) -> Result<Documentation, Error> {
     Ok(Documentation {
         contributing: check::path_exists(Globs {
             root,
-            patterns: CONTRIBUTING,
+            patterns: CONTRIBUTING_FILE,
             case_sensitive: false,
         })?,
         maintainers: check::path_exists(Globs {
             root,
-            patterns: MAINTAINERS,
+            patterns: MAINTAINERS_FILE,
             case_sensitive: false,
         })?,
         readme: check::path_exists(Globs {
             root,
-            patterns: README,
+            patterns: README_FILE,
             case_sensitive: true,
         })?,
     })
@@ -65,7 +65,7 @@ fn lint_documentation(root: &Path) -> Result<Documentation, Error> {
 fn lint_license(root: &Path) -> Result<License, Error> {
     let spdx_id = check::license(Globs {
         root,
-        patterns: LICENSE,
+        patterns: LICENSE_FILE,
         case_sensitive: true,
     })?;
 

--- a/web/src/data.tsx
+++ b/web/src/data.tsx
@@ -94,28 +94,18 @@ export const REPORT_OPTIONS: ReportOptionInfo = {
   [ReportOption.Adopters]: {
     icon: <ImOffice />,
     name: 'Adopters',
-    legend: (
-      <span>
-        The <em>adopters</em> file contains a list of organizations using this project in production or at stages of
-        testing
-      </span>
-    ),
+    legend: <span>List of organizations using this project in production or at stages of testing</span>,
     description: (
       <span>
         We check that an <code>adopters*</code> <em>(no case sensitive)</em> file exists at the <code>root</code> of the
-        repository
+        repository or that the <code>README</code> file contains an <strong>adopters</strong> header
       </span>
     ),
   },
   [ReportOption.Changelog]: {
     icon: <CgFileDocument />,
     name: 'Changelog',
-    legend: (
-      <span>
-        A <em>changelog</em> is a file which contains a curated, chronologically ordered list of notable changes for
-        each version
-      </span>
-    ),
+    legend: <span>A curated, chronologically ordered list of notable changes for each version</span>,
     description: (
       <span>
         We check that an <code>changelog*</code> <em>(no case sensitive)</em> file exists at the <code>root</code> of
@@ -135,7 +125,8 @@ export const REPORT_OPTIONS: ReportOptionInfo = {
     description: (
       <span>
         We check that a <code>code*of*conduct.md*</code> <em>(no case sensitive)</em> file exists at the{' '}
-        <code>root</code> of the repository or in the <code>docs</code> directory
+        <code>root</code> of the repository or in the <code>docs</code> directory or that the <code>README</code> file
+        contains a <strong>code of conduct</strong> header
       </span>
     ),
   },
@@ -158,11 +149,12 @@ export const REPORT_OPTIONS: ReportOptionInfo = {
   [ReportOption.Governance]: {
     icon: <GiTiedScroll />,
     name: 'Governance',
-    legend: <span>File that explains how the governance and committer process works in the repository</span>,
+    legend: <span>Document that explains how the governance and committer process works in the repository</span>,
     description: (
       <span>
         We check that a <code>governance*</code> <em>(no case sensitive)</em> file exists at the <code>root</code> of
-        the repository or in the <code>docs</code> directory
+        the repository or in the <code>docs</code> directory or that the <code>README</code> file contains a
+        <strong>governance</strong> header
       </span>
     ),
   },
@@ -202,15 +194,12 @@ export const REPORT_OPTIONS: ReportOptionInfo = {
     icon: <RiRoadMapLine />,
     name: 'Roadmap',
     legend: (
-      <span>
-        The <em>roadmap</em> file defines a high-level overview of the project's goals and deliverables ideally
-        presented on a timeline
-      </span>
+      <span>Defines a high-level overview of the project's goals and deliverables ideally presented on a timeline</span>
     ),
     description: (
       <span>
         We check that a <code>roadmap*</code> <em>(no case sensitive)</em> file exists at the <code>root</code> of the
-        repository
+        repository or that the <code>README</code> file contains a <strong>roadmap</strong> header
       </span>
     ),
   },
@@ -276,16 +265,12 @@ export const REPORT_OPTIONS: ReportOptionInfo = {
   [ReportOption.SecurityPolicy]: {
     icon: <BiShieldQuarter />,
     name: 'Security policy',
-    legend: (
-      <span>
-        Clearly documented security processes explaining how to report security issues to the project, and describing
-        how the project provides updated releases or patches to resolve security vulnerabilities
-      </span>
-    ),
+    legend: <span>Clearly documented security processes explaining how to report security issues to the project</span>,
     description: (
       <span>
         We check that a <code>security*</code> <em>(no case sensitive)</em> file exists at the <code>root</code> of the
-        repository or in the <code>docs</code> or <code>.github</code> directories
+        repository, in the <code>docs</code> or <code>.github</code> directories or that the <code>README</code> file
+        contains a <strong>security</strong> header
       </span>
     ),
   },


### PR DESCRIPTION
The checks below now support checking for headers in the `README` file in addition to checking for the specific files:

- Adopters
- Code of conduct
- Governance
- Roadmap
- Security policy

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>
Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>
Co-authored-by: Sergio Castaño Arteaga <tegioz@icloud.com>
Co-authored-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>