### PR TITLE
Use .github repo default community health files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "clap",
  "git2",
  "glob",
+ "http",
  "lazy_static",
  "octocrab",
  "regex",

--- a/clomonitor-core/Cargo.toml
+++ b/clomonitor-core/Cargo.toml
@@ -10,6 +10,7 @@ clap = { version = "3.0.7", features = ["derive"] }
 chrono = "0.4.19"
 git2 = "0.14.1"
 glob = "0.3.0"
+http = "0.2.6"
 lazy_static = "1.4.0"
 octocrab = "0.15.4"
 regex = "1.5.4"

--- a/clomonitor-core/src/linter/check/content.rs
+++ b/clomonitor-core/src/linter/check/content.rs
@@ -1,5 +1,6 @@
 use super::path::{self, Globs};
 use anyhow::Error;
+use lazy_static::lazy_static;
 use regex::{Regex, RegexSet};
 use reqwest;
 use std::fs;
@@ -56,7 +57,10 @@ where
     R: IntoIterator,
     R::Item: AsRef<str>,
 {
-    let content = reqwest::get(url).await?.text().await?;
+    lazy_static! {
+        static ref HTTP_CLIENT: reqwest::Client = reqwest::Client::new();
+    }
+    let content = HTTP_CLIENT.get(url).send().await?.text().await?;
     let re = RegexSet::new(regexps)?;
     Ok(re.is_match(&content))
 }

--- a/clomonitor-core/src/linter/mod.rs
+++ b/clomonitor-core/src/linter/mod.rs
@@ -57,7 +57,7 @@ pub async fn lint(options: LintOptions<'_>) -> Result<Report, Error> {
     // Run the linter corresponding to the repository kind provided
     Ok(match &options.kind {
         RepositoryKind::Primary => Report::Primary(primary::lint(options).await?),
-        RepositoryKind::Secondary => Report::Secondary(secondary::lint(options)?),
+        RepositoryKind::Secondary => Report::Secondary(secondary::lint(options).await?),
     })
 }
 


### PR DESCRIPTION
The following checks now check if the corresponding default community health file exists in the .github repository:

- Code of conduct
- Contributing
- Security

https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file

Closes #68

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>