### PR TITLE
Track repositories once a day if they don't change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ name = "clomonitor-tracker"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "clomonitor-core",
  "config",
@@ -1600,6 +1601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04619f94ba0cc80999f4fc7073607cb825bc739a883cb6d20900fc5e009d6b0d"
 dependencies = [
  "bytes",
+ "chrono",
  "fallible-iterator",
  "postgres-protocol",
  "serde 1.0.136",

--- a/clomonitor-tracker/Cargo.toml
+++ b/clomonitor-tracker/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.52"
 clap = { version = "3.0.7", features = ["derive"] }
 clomonitor-core = { path = "../clomonitor-core" }
 config = "0.11.0"
+chrono = "0.4.19"
 deadpool-postgres = { version = "0.10.1", features = ["serde"] }
 futures = "0.3.19"
 openssl = { version = "0.10", features = ["vendored"] }
@@ -18,7 +19,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.74"
 tempdir = "0.3.7"
 tokio = { version = "1", features = ["macros", "process", "rt-multi-thread", "time"] }
-tokio-postgres = { version = "0.7.5", features = ["with-uuid-0_8", "with-serde_json-1"] }
+tokio-postgres = { version = "0.7.5", features = ["with-uuid-0_8", "with-serde_json-1", "with-chrono-0_4"] }
 tracing = "0.1.29"
 tracing-subscriber = "0.3.6"
 uuid = "0.8.2"

--- a/database/migrations/schema/001_initial.sql
+++ b/database/migrations/schema/001_initial.sql
@@ -60,6 +60,7 @@ create table if not exists repository (
     digest text,
     score jsonb,
     created_at timestamptz default current_timestamp not null,
+    updated_at timestamptz default current_timestamp not null,
     project_id uuid not null references project on delete cascade,
     unique (project_id, name)
 );

--- a/database/tests/schema/schema.sql
+++ b/database/tests/schema/schema.sql
@@ -70,6 +70,7 @@ select columns_are('repository', array[
     'digest',
     'score',
     'created_at',
+    'updated_at',
     'project_id'
 ]);
 


### PR DESCRIPTION
We improve existing checks and add new ones often, so this will help to
keep the reports up to date for repositories that are not updated very
frequently.

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>