### PR TITLE
Allow searching projects by display name

### DIFF
--- a/database/migrations/functions/projects/search_projects.sql
+++ b/database/migrations/functions/projects/search_projects.sql
@@ -44,7 +44,9 @@ begin
         join organization o using (organization_id)
         where score is not null
         and
-            case when v_text is not null then p.name ~* v_text else true end
+            case when v_text is not null then
+                (p.name ~* v_text or p.display_name ~* v_text) else true
+            end
         and
             case when cardinality(v_category) > 0
             then p.category_id = any(v_category) else true end


### PR DESCRIPTION
At the moment the projects search only looks for a text match in the
name. But sometimes the name may contain some unexpected characters (a
'-', for example) and the search produces no results. Searching on both
should fix this.

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>