### PR TITLE
Enable back commits signature check for DCO

### DIFF
--- a/clomonitor-core/src/linter/check/git.rs
+++ b/clomonitor-core/src/linter/check/git.rs
@@ -1,0 +1,45 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::path::Path;
+
+/// Maximum number of commits used to check if the repository requires DCO.
+pub const DCO_MAX_COMMITS: usize = 20;
+
+/// Check if the last commits on the git repository located in the path
+/// provided have the DCO signature.
+pub(crate) fn commits_have_dco_signature(path: &Path) -> Result<bool, git2::Error> {
+    lazy_static! {
+        static ref MERGE_PR_RE: Regex = Regex::new(r"^Merge pull request ").unwrap();
+        static ref MERGE_BRANCH_RE: Regex = Regex::new(r"^Merge branch ").unwrap();
+        static ref DCO_SIGNATURE_RE: Regex = Regex::new(r"(?m)^Signed-off-by: ").unwrap();
+    }
+
+    let repo = git2::Repository::open(path)?;
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push_head()?;
+
+    let (mut processed, mut signed_off, mut merge) = (0, 0, 0);
+    for oid in revwalk.take(DCO_MAX_COMMITS) {
+        if oid.is_err() {
+            continue;
+        }
+        let commit = repo.find_commit(oid.unwrap())?;
+        processed += 1;
+        if let Some(msg) = commit.message() {
+            if MERGE_PR_RE.is_match(msg) || MERGE_BRANCH_RE.is_match(msg) {
+                merge += 1;
+                continue;
+            }
+            if DCO_SIGNATURE_RE.is_match(msg) {
+                signed_off += 1;
+            } else {
+                return Ok(false);
+            }
+        }
+    }
+
+    if signed_off == processed - merge {
+        return Ok(true);
+    }
+    Ok(false)
+}

--- a/clomonitor-core/src/linter/check/mod.rs
+++ b/clomonitor-core/src/linter/check/mod.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 pub(crate) mod content;
+pub(crate) mod git;
 pub(crate) mod github;
 pub(crate) mod license;
 pub(crate) mod metadata;
@@ -275,6 +276,13 @@ pub(crate) async fn contributing(input: &CheckInput<'_>) -> Result<CheckOutput> 
 
 /// Developer Certificate of Origin check.
 pub(crate) async fn dco(input: &CheckInput<'_>) -> Result<CheckOutput> {
+    // DCO signature in commits
+    if let Ok(passed) = git::commits_have_dco_signature(&input.opts.root) {
+        if passed {
+            return Ok(true.into());
+        }
+    }
+
     // DCO check in Github
     Ok(
         github::has_check(&input.svc.github_client, &input.opts.url, &*DCO_IN_GH)

--- a/clomonitor-tracker/src/repository.rs
+++ b/clomonitor-tracker/src/repository.rs
@@ -104,7 +104,7 @@ impl Repository {
     async fn clone(&self, dst: &Path) -> Result<()> {
         let output = Command::new("git")
             .arg("clone")
-            .arg("--depth=1")
+            .arg("--depth=10")
             .arg(&self.url)
             .arg(dst)
             .output()

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -406,6 +406,8 @@ Mechanism for contributors to certify that they wrote or have the right to submi
 
 This check passes if:
 
+- The last commits in the repository have the DCO signature (*Signed-off-by*). Merge pull request and merge branch commits are ignored for this check.
+
 - A DCO check is found in the last closed PR on Github. Regexps used:
 
 ```sh


### PR DESCRIPTION
This was disabled in #222, but it can still be useful for some projects.

Closes #259

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>