### PR TITLE
Fix issue building container images

### DIFF
--- a/clomonitor-linter/Dockerfile
+++ b/clomonitor-linter/Dockerfile
@@ -10,8 +10,7 @@ RUN cargo build --release
 # Get OpenSSF scorecard binary
 FROM alpine:3.15 AS scorecard
 WORKDIR /tmp
-RUN wget -O scorecard.tar.gz https://github.com/ossf/scorecard/releases/download/v4.4.0/scorecard_4.4.0_linux_amd64.tar.gz
-RUN tar xvfz scorecard.tar.gz
+RUN wget -O scorecard-linux-amd64 https://github.com/ossf/scorecard/releases/download/v4.4.0/scorecard-linux-amd64
 
 # Final stage
 FROM alpine:3.15

--- a/clomonitor-tracker/Dockerfile
+++ b/clomonitor-tracker/Dockerfile
@@ -11,8 +11,7 @@ RUN cargo build --release
 # Get OpenSSF scorecard binary
 FROM alpine:3.15 AS scorecard
 WORKDIR /tmp
-RUN wget -O scorecard.tar.gz https://github.com/ossf/scorecard/releases/download/v4.4.0/scorecard_4.4.0_linux_amd64.tar.gz
-RUN tar xvfz scorecard.tar.gz
+RUN wget -O scorecard-linux-amd64 https://github.com/ossf/scorecard/releases/download/v4.4.0/scorecard-linux-amd64
 
 # Final stage
 FROM alpine:3.15


### PR DESCRIPTION
The Scorecard v4.4.0 release doesn't have a .tar.gz asset for the linux/amd64 platform as previous versions had. Instead it provides an uncompressed version named `scorecard-linux-amd64`.

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>