### PR TITLE
Add endpoint to export all repositories checks

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -81,7 +81,7 @@ tracker:
       repository: clomonitor/tracker
     resources: {}
   # Number of repositories to process concurrently
-  concurrency: 10
+  concurrency: 5
 
 # Values for postgresql chart dependency
 postgresql:

--- a/clomonitor-apiserver/src/db.rs
+++ b/clomonitor-apiserver/src/db.rs
@@ -45,6 +45,9 @@ pub(crate) trait DB {
         project: &str,
     ) -> Result<Option<Score>>;
 
+    /// Get all repositories including checks details.
+    async fn repositories_with_checks(&self) -> Result<String>;
+
     /// Search projects that match the criteria provided.
     async fn search_projects(&self, input: &SearchProjectsInput) -> Result<(Count, JsonString)>;
 
@@ -144,6 +147,22 @@ impl DB for PgDB {
             Some(Json(score)) => Ok(Some(score)),
             None => Ok(None),
         }
+    }
+
+    async fn repositories_with_checks(&self) -> Result<String> {
+        let rows = self
+            .pool
+            .get()
+            .await?
+            .query("select get_repositories_with_checks()", &[])
+            .await?;
+        let mut repos = String::new();
+        for row in rows {
+            let repo = row.get(0);
+            repos.push_str(repo);
+            repos.push('\n');
+        }
+        Ok(repos)
     }
 
     async fn search_projects(&self, input: &SearchProjectsInput) -> Result<(Count, JsonString)> {

--- a/clomonitor-apiserver/src/handlers.rs
+++ b/clomonitor-apiserver/src/handlers.rs
@@ -13,7 +13,7 @@ use axum::{
 };
 use clomonitor_core::score::Score;
 use config::Config;
-use mime::{APPLICATION_JSON, HTML, PNG};
+use mime::{APPLICATION_JSON, CSV, HTML, PNG};
 use serde_json::json;
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 use tera::{Context, Tera};
@@ -249,6 +249,21 @@ pub(crate) async fn report_summary_svg(
         }
         None => Err(StatusCode::NOT_FOUND),
     }
+}
+
+/// Handler that returns all repositories with checks details in CSV format.
+pub(crate) async fn repositories_checks(Extension(db): Extension<DynDB>) -> impl IntoResponse {
+    // Get all repositories from database
+    let repos = db
+        .repositories_with_checks()
+        .await
+        .map_err(internal_error)?;
+
+    Response::builder()
+        .header(CACHE_CONTROL, "max-age=3600")
+        .header(CONTENT_TYPE, CSV.as_ref())
+        .body(Full::from(repos))
+        .map_err(internal_error)
 }
 
 /// Handler that allows searching for projects.

--- a/clomonitor-apiserver/src/router.rs
+++ b/clomonitor-apiserver/src/router.rs
@@ -62,6 +62,7 @@ pub(crate) fn setup(cfg: Arc<Config>, db: DynDB) -> Result<Router> {
             "/projects/:foundation/:org/:project/report-summary.png",
             get(report_summary_png),
         )
+        .route("/data/repositories.csv", get(repositories_checks))
         .nest("/api", api_routes)
         .nest(
             "/docs",

--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -1,5 +1,6 @@
 {{ template "projects/get_project.sql" }}
 {{ template "projects/search_projects.sql" }}
+{{ template "repositories/get_repositories_with_checks.sql" }}
 {{ template "stats/average_section_score.sql" }}
 {{ template "stats/repositories_passing_check.sql" }}
 {{ template "stats/get_stats.sql" }}

--- a/database/migrations/functions/repositories/get_repositories_with_checks.sql
+++ b/database/migrations/functions/repositories/get_repositories_with_checks.sql
@@ -1,0 +1,51 @@
+-- Returns all repositories including checks details.
+create or replace function get_repositories_with_checks()
+returns setof text as $$
+    with repositories as (
+        select
+            o.foundation,
+            p.name as project,
+            r.url as repository_url,
+            r.check_sets,
+            (rp.data->'documentation'->'adopters'->'passed')::boolean as adopters,
+            (rp.data->'documentation'->'changelog'->'passed')::boolean as changelog,
+            (rp.data->'documentation'->'code_of_conduct'->'passed')::boolean as code_of_conduct,
+            (rp.data->'documentation'->'contributing'->'passed')::boolean as contributing,
+            (rp.data->'documentation'->'governance'->'passed')::boolean as governance,
+            (rp.data->'documentation'->'maintainers'->'passed')::boolean as maintainers,
+            (rp.data->'documentation'->'readme'->'passed')::boolean as readme,
+            (rp.data->'documentation'->'roadmap'->'passed')::boolean as roadmap,
+            (rp.data->'documentation'->'website'->'passed')::boolean as website,
+            (rp.data->'license'->'approved'->'passed')::boolean as license_approved,
+            (rp.data->'license'->'scanning'->'passed')::boolean as license_scanning,
+            (rp.data->'license'->'spdx_id'->>'value')::text as license_spdx_id,
+            (rp.data->'best_practices'->'artifacthub_badge'->'passed')::boolean as artifacthub_badge,
+            (rp.data->'best_practices'->'cla'->'passed')::boolean as cla,
+            (rp.data->'best_practices'->'community_meeting'->'passed')::boolean as community_meeting,
+            (rp.data->'best_practices'->'dco'->'passed')::boolean as dco,
+            (rp.data->'best_practices'->'ga4'->'passed')::boolean as ga4,
+            (rp.data->'best_practices'->'openssf_badge'->'passed')::boolean as openssf_badge,
+            (rp.data->'best_practices'->'recent_release'->'passed')::boolean as recent_release,
+            (rp.data->'best_practices'->'slack_presence'->'passed')::boolean as slack_presence,
+            (rp.data->'security'->'binary_artifacts'->'passed')::boolean as binary_artifacts,
+            (rp.data->'security'->'branch_protection'->'passed')::boolean as branch_protection,
+            (rp.data->'security'->'code_review'->'passed')::boolean as code_review,
+            (rp.data->'security'->'dangerous_workflow'->'passed')::boolean as dangerous_workflow,
+            (rp.data->'security'->'dependency_update_tool'->'passed')::boolean as dependency_update_tool,
+            (rp.data->'security'->'maintained'->'passed')::boolean as maintained,
+            (rp.data->'security'->'sbom'->'passed')::boolean as sbom,
+            (rp.data->'security'->'security_policy'->'passed')::boolean as security_policy,
+            (rp.data->'security'->'signed_releases'->'passed')::boolean as signed_releases,
+            (rp.data->'security'->'token_permissions'->'passed')::boolean as token_permissions,
+            (rp.data->'security'->'vulnerabilities'->'passed')::boolean as vulnerabilities,
+            (rp.data->'legal'->'trademark_disclaimer'->'passed')::boolean as trademark_disclaimer
+        from organization o
+        join project p using (organization_id)
+        join repository r using (project_id)
+        join report rp using (repository_id)
+        order by o.foundation asc, p.name asc
+    )
+    select 'Foundation,Project,Repository URL,Check Sets,Adopters,Changelog,Code of Conduct,Contributing,Governance,Maintainers,Readme,Roadmap,Website,License Approved,License Scanning,License SPDX ID,ArtifactHub Badge,CLA,Community Meeting,DCO,GA4,OpenSSF Badge,Recent Release,Slack Presence,Binary Artifacts,Branch Protection,Code Review,Dangerous Workflow,Dependency Update Tool,Maintained,SBOM,Security Policy,Signed Releases,Token Permissions,Vulnerabilities,Trademark Disclaimer'
+    union all
+    select rtrim(ltrim(r.*::text, '('), ')') from repositories r;
+$$ language sql;

--- a/database/tests/schema/schema.sql
+++ b/database/tests/schema/schema.sql
@@ -1,6 +1,6 @@
 -- Start transaction and plan tests
 begin;
-select plan(17);
+select plan(18);
 
 -- Check expected extension exist
 select has_extension('pgcrypto');
@@ -81,6 +81,9 @@ select indexes_are('repository', array[
 -- Projects
 select has_function('get_project');
 select has_function('search_projects');
+-- Repositories
+select has_function('get_repositories_with_checks');
+-- Stats
 select has_function('repositories_passing_check');
 select has_function('get_stats');
 


### PR DESCRIPTION
This new endpoint allows exporting all repositories along with all checks details in CSV format.

The data is generated dynamically so you can get a fresh copy everytime you need it.

The new endpoint is located at <https://clomonitor.io/data/repositories.csv>.

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>