### PR TITLE
Add generic analytics check

### DIFF
--- a/clomonitor-core/src/config.rs
+++ b/clomonitor-core/src/config.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 // Checks identifiers
 pub const ADOPTERS: &str = "adopters";
+pub const ANALYTICS: &str = "analytics";
 pub const ARTIFACTHUB_BADGE: &str = "artifacthub_badge";
 pub const BINARY_ARTIFACTS: &str = "binary_artifacts";
 pub const BRANCH_PROTECTION: &str = "branch_protection";
@@ -16,7 +17,6 @@ pub const CONTRIBUTING: &str = "contributing";
 pub const DANGEROUS_WORKFLOW: &str = "dangerous_workflow";
 pub const DEPENDENCY_UPDATE_TOOL: &str = "dependency_update_tool";
 pub const DCO: &str = "dco";
-pub const GA4: &str = "ga4";
 pub const GITHUB_DISCUSSIONS: &str = "github_discussions";
 pub const GOVERNANCE: &str = "governance";
 pub const LICENSE_APPROVED: &str = "license_approved";
@@ -59,11 +59,11 @@ lazy_static! {
         m.insert(LICENSE_SPDX, 5);
 
         // Best practices
+        m.insert(ANALYTICS, 1);
         m.insert(ARTIFACTHUB_BADGE, 1);
         m.insert(CLA, 1);
         m.insert(COMMUNITY_MEETING, 3);
         m.insert(DCO, 1);
-        m.insert(GA4, 1);
         m.insert(GITHUB_DISCUSSIONS, 0);
         m.insert(OPENSSF_BADGE, 10);
         m.insert(RECENT_RELEASE, 3);
@@ -144,10 +144,10 @@ lazy_static! {
             CheckSet::Community,
             vec![
                 ADOPTERS,
+                ANALYTICS,
                 CODE_OF_CONDUCT,
                 COMMUNITY_MEETING,
                 CONTRIBUTING,
-                GA4,
                 GITHUB_DISCUSSIONS,
                 GOVERNANCE,
                 README,

--- a/clomonitor-core/src/linter/check/patterns.rs
+++ b/clomonitor-core/src/linter/check/patterns.rs
@@ -140,9 +140,14 @@ lazy_static! {
     ).expect("invalid exprs in FOSSA_URL");
 
     #[rustfmt::skip]
-    pub(crate) static ref GA4_IN_WEBSITE: RegexSet = RegexSet::new(vec![
-        "G-[A-Z0-9]{8,10}",
-    ]).expect("invalid exprs in GA4_IN_WEBSITE");
+    pub(crate) static ref GA3_IN_WEBSITE: Regex = Regex::new(
+        "UA-[0-9]+-[0-9]+",
+    ).expect("invalid exprs in GA3_IN_WEBSITE");
+
+    #[rustfmt::skip]
+    pub(crate) static ref GA4_IN_WEBSITE: Regex = Regex::new(
+        "G-[A-Z0-9]+",
+    ).expect("invalid exprs in GA4_IN_WEBSITE");
 
     #[rustfmt::skip]
     pub(crate) static ref GITHUB_REPO_URL: Regex = Regex::new(
@@ -155,6 +160,11 @@ lazy_static! {
         r"(?im)^governance$",
         r"(?i)\[.*governance.*\]\(.*\)",
     ]).expect("invalid exprs in GOVERNANCE_IN_README");
+
+    #[rustfmt::skip]
+    pub(crate) static ref HUBSPOT_IN_WEBSITE: Regex = Regex::new(
+        r"//js.hs-scripts.com/.+\.js",
+    ).expect("invalid exprs in HUBSPOT_IN_WEBSITE");
 
     #[rustfmt::skip]
     pub(crate) static ref MAINTAINERS_IN_README: RegexSet = RegexSet::new(vec![
@@ -346,6 +356,12 @@ Contributing
     }
 
     #[test]
+    fn ga3_in_website() {
+        assert!(GA3_IN_WEBSITE.is_match("UA-123456-0"));
+        assert!(GA3_IN_WEBSITE.is_match("UA-12345678-90"));
+    }
+
+    #[test]
     fn ga4_in_website() {
         assert!(GA4_IN_WEBSITE.is_match("G-XXXXXXXXXX"));
         assert!(GA4_IN_WEBSITE.is_match("G-NVMH1T3GEK"));
@@ -377,6 +393,11 @@ Governance
             "
         ));
         assert!(GOVERNANCE_IN_README.is_match("[Project governance](...)"));
+    }
+
+    #[test]
+    fn hubspot_in_website() {
+        assert!(HUBSPOT_IN_WEBSITE.is_match("https://js.hs-scripts.com/123.js"));
     }
 
     #[test]

--- a/clomonitor-core/src/linter/mod.rs
+++ b/clomonitor-core/src/linter/mod.rs
@@ -109,11 +109,11 @@ pub struct License {
 /// BestPractices section of the report.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BestPractices {
+    pub analytics: Option<CheckOutput<Vec<String>>>,
     pub artifacthub_badge: Option<CheckOutput>,
     pub cla: Option<CheckOutput>,
     pub community_meeting: Option<CheckOutput>,
     pub dco: Option<CheckOutput>,
-    pub ga4: Option<CheckOutput>,
     pub github_discussions: Option<CheckOutput>,
     pub openssf_badge: Option<CheckOutput>,
     pub recent_release: Option<CheckOutput>,
@@ -176,9 +176,9 @@ pub async fn lint(opts: &LintOptions, svc: &LintServices) -> Result<Report> {
     };
 
     // Run some async checks
-    let (contributing, ga4, trademark_disclaimer) = tokio::join!(
+    let (analytics, contributing, trademark_disclaimer) = tokio::join!(
+        run_async_check(ANALYTICS, analytics, &input),
         run_async_check(CONTRIBUTING, contributing, &input),
-        run_async_check(GA4, ga4, &input),
         run_async_check(TRADEMARK_DISCLAIMER, trademark_disclaimer, &input),
     );
 
@@ -208,11 +208,11 @@ pub async fn lint(opts: &LintOptions, svc: &LintServices) -> Result<Report> {
             license_spdx_id: spdx_id,
         },
         best_practices: BestPractices {
+            analytics,
             artifacthub_badge: run_check(ARTIFACTHUB_BADGE, artifacthub_badge, &input),
             cla: run_check(CLA, cla, &input),
             community_meeting: run_check(COMMUNITY_MEETING, community_meeting, &input),
             dco: run_check(DCO, dco, &input),
-            ga4,
             github_discussions: run_check(GITHUB_DISCUSSIONS, github_discussions, &input),
             openssf_badge: run_check(OPENSSF_BADGE, openssf_badge, &input),
             recent_release: run_check(RECENT_RELEASE, recent_release, &input),

--- a/clomonitor-core/src/score/mod.rs
+++ b/clomonitor-core/src/score/mod.rs
@@ -84,11 +84,11 @@ pub fn calculate(report: &Report) -> Score {
     // Best practices
     let bp = &report.best_practices;
     (score.best_practices, score.best_practices_weight) = calculate_section_score_and_weight(&[
+        (ANALYTICS, should_score(&bp.analytics)),
         (ARTIFACTHUB_BADGE, should_score(&bp.artifacthub_badge)),
         (CLA, should_score(&bp.cla)),
         (COMMUNITY_MEETING, should_score(&bp.community_meeting)),
         (DCO, should_score(&bp.dco)),
-        (GA4, should_score(&bp.ga4)),
         (GITHUB_DISCUSSIONS, should_score(&bp.github_discussions)),
         (OPENSSF_BADGE, should_score(&bp.openssf_badge)),
         (RECENT_RELEASE, should_score(&bp.recent_release)),
@@ -328,6 +328,7 @@ mod tests {
                     license_spdx_id: Some(Some("Apache-2.0".to_string()).into()),
                 },
                 best_practices: BestPractices {
+                    analytics: Some(true.into()),
                     artifacthub_badge: Some(CheckOutput {
                         exempt: true,
                         ..Default::default()
@@ -335,7 +336,6 @@ mod tests {
                     cla: Some(true.into()),
                     community_meeting: Some(true.into()),
                     dco: Some(true.into()),
-                    ga4: Some(true.into()),
                     github_discussions: Some(true.into()),
                     openssf_badge: Some(true.into()),
                     recent_release: Some(true.into()),
@@ -396,6 +396,7 @@ mod tests {
                     license_spdx_id: Some(false.into()),
                 },
                 best_practices: BestPractices {
+                    analytics: Some(false.into()),
                     artifacthub_badge: Some(CheckOutput {
                         exempt: false,
                         ..Default::default()
@@ -403,7 +404,6 @@ mod tests {
                     cla: Some(false.into()),
                     community_meeting: Some(false.into()),
                     dco: Some(false.into()),
-                    ga4: Some(false.into()),
                     github_discussions: Some(false.into()),
                     openssf_badge: Some(false.into()),
                     recent_release: Some(false.into()),
@@ -470,6 +470,7 @@ mod tests {
                     license_spdx_id: Some(Some("Apache-2.0".to_string()).into()),
                 },
                 best_practices: BestPractices {
+                    analytics: Some(true.into()),
                     artifacthub_badge: Some(CheckOutput {
                         exempt: true,
                         ..Default::default()
@@ -477,7 +478,6 @@ mod tests {
                     cla: Some(true.into()),
                     community_meeting: None,
                     dco: Some(true.into()),
-                    ga4: Some(true.into()),
                     github_discussions: Some(true.into()),
                     openssf_badge: Some(true.into()),
                     recent_release: Some(true.into()),

--- a/clomonitor-linter/src/table.rs
+++ b/clomonitor-linter/src/table.rs
@@ -125,6 +125,21 @@ pub(crate) fn display(
             cell_check(&report.license.license_scanning),
         ])
         .add_row(vec![
+            cell_entry("Best practices / Analytics"),
+            if let Some(value) = report
+                .best_practices
+                .analytics
+                .as_ref()
+                .and_then(|analytics| analytics.value.as_ref())
+            {
+                Cell::new(value.join(" · "))
+                    .set_alignment(CellAlignment::Center)
+                    .add_attribute(Attribute::Bold)
+            } else {
+                cell_check(&report.best_practices.analytics)
+            },
+        ])
+        .add_row(vec![
             cell_entry("Best practices / Artifact Hub badge"),
             cell_check(&report.best_practices.artifacthub_badge),
         ])
@@ -143,10 +158,6 @@ pub(crate) fn display(
         .add_row(vec![
             cell_entry("Best practices / GitHub discussions"),
             cell_check(&report.best_practices.github_discussions),
-        ])
-        .add_row(vec![
-            cell_entry("Best practices / Google Analytics 4"),
-            cell_check(&report.best_practices.ga4),
         ])
         .add_row(vec![
             cell_entry("Best practices / OpenSSF (CII) badge"),
@@ -329,6 +340,7 @@ mod tests {
                 license_spdx_id: Some(Some("Apache-2.0".to_string()).into()),
             },
             best_practices: BestPractices {
+                analytics: Some(Some(vec!["GA3".to_string(), "GA4".to_string()]).into()),
                 artifacthub_badge: Some(CheckOutput {
                     exempt: true,
                     ..Default::default()
@@ -336,7 +348,6 @@ mod tests {
                 cla: Some(true.into()),
                 community_meeting: Some(true.into()),
                 dco: Some(true.into()),
-                ga4: Some(true.into()),
                 github_discussions: Some(true.into()),
                 openssf_badge: Some(true.into()),
                 recent_release: Some(true.into()),

--- a/clomonitor-linter/src/testdata/display.golden
+++ b/clomonitor-linter/src/testdata/display.golden
@@ -58,6 +58,8 @@ Checks summary
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
 │ License / Scanning                   ┆      ✓     │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ Best practices / Analytics           ┆  GA3 · GA4 │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
 │ Best practices / Artifact Hub badge  ┆   Exempt   │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
 │ Best practices / CLA                 ┆      ✓     │
@@ -67,8 +69,6 @@ Checks summary
 │ Best practices / DCO                 ┆      ✓     │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
 │ Best practices / GitHub discussions  ┆      ✓     │
-├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Best practices / Google Analytics 4  ┆      ✓     │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
 │ Best practices / OpenSSF (CII) badge ┆      ✓     │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤

--- a/database/migrations/functions/repositories/get_repositories_with_checks.sql
+++ b/database/migrations/functions/repositories/get_repositories_with_checks.sql
@@ -19,11 +19,14 @@ returns setof text as $$
             (rp.data->'license'->'license_approved'->'passed')::boolean as license_approved,
             (rp.data->'license'->'license_scanning'->'passed')::boolean as license_scanning,
             coalesce((rp.data->'license'->'license_spdx_id'->>'value')::text, 'Not detected') as license_spdx_id,
+            (
+                select string_agg(item #>> '{}', ' ')
+                from jsonb_array_elements(rp.data->'best_practices'->'analytics'->'value') as item
+            ) as analytics,
             (rp.data->'best_practices'->'artifacthub_badge'->'passed')::boolean as artifacthub_badge,
             (rp.data->'best_practices'->'cla'->'passed')::boolean as cla,
             (rp.data->'best_practices'->'community_meeting'->'passed')::boolean as community_meeting,
             (rp.data->'best_practices'->'dco'->'passed')::boolean as dco,
-            (rp.data->'best_practices'->'ga4'->'passed')::boolean as ga4,
             (rp.data->'best_practices'->'github_discussions'->'passed')::boolean as github_discussions,
             (rp.data->'best_practices'->'openssf_badge'->'passed')::boolean as openssf_badge,
             (rp.data->'best_practices'->'recent_release'->'passed')::boolean as recent_release,
@@ -46,7 +49,7 @@ returns setof text as $$
         join report rp using (repository_id)
         order by o.foundation asc, p.name asc
     )
-    select 'Foundation,Project,Repository URL,Check Sets,Adopters,Changelog,Code of Conduct,Contributing,Governance,Maintainers,Readme,Roadmap,Website,License Approved,License Scanning,License SPDX ID,ArtifactHub Badge,CLA,Community Meeting,DCO,GA4,GitHub discussions,OpenSSF Badge,Recent Release,Slack Presence,Binary Artifacts,Branch Protection,Code Review,Dangerous Workflow,Dependency Update Tool,Maintained,SBOM,Security Policy,Signed Releases,Token Permissions,Vulnerabilities,Trademark Disclaimer'
+    select 'Foundation,Project,Repository URL,Check Sets,Adopters,Changelog,Code of Conduct,Contributing,Governance,Maintainers,Readme,Roadmap,Website,License Approved,License Scanning,License SPDX ID,Analytics,ArtifactHub Badge,CLA,Community Meeting,DCO,GitHub discussions,OpenSSF Badge,Recent Release,Slack Presence,Binary Artifacts,Branch Protection,Code Review,Dangerous Workflow,Dependency Update Tool,Maintained,SBOM,Security Policy,Signed Releases,Token Permissions,Vulnerabilities,Trademark Disclaimer'
     union all
     select rtrim(ltrim(r.*::text, '('), ')') from repositories r;
 $$ language sql;

--- a/database/migrations/functions/stats/get_stats.sql
+++ b/database/migrations/functions/stats/get_stats.sql
@@ -146,11 +146,11 @@ returns json as $$
                     'license_spdx_id', repositories_passing_check(p_foundation, 'license', 'license_spdx_id')
                 ),
                 'best_practices', json_build_object(
+                    'analytics', repositories_passing_check(p_foundation, 'best_practices', 'analytics'),
                     'artifacthub_badge', repositories_passing_check(p_foundation, 'best_practices', 'artifacthub_badge'),
                     'cla', repositories_passing_check(p_foundation, 'best_practices', 'cla'),
                     'community_meeting', repositories_passing_check(p_foundation, 'best_practices', 'community_meeting'),
                     'dco', repositories_passing_check(p_foundation, 'best_practices', 'dco'),
-                    'ga4', repositories_passing_check(p_foundation, 'best_practices', 'ga4'),
                     'github_discussions', repositories_passing_check(p_foundation, 'best_practices', 'github_discussions'),
                     'openssf_badge', repositories_passing_check(p_foundation, 'best_practices', 'openssf_badge'),
                     'recent_release', repositories_passing_check(p_foundation, 'best_practices', 'recent_release'),

--- a/database/tests/functions/stats/get_stats.sql
+++ b/database/tests/functions/stats/get_stats.sql
@@ -214,7 +214,7 @@ insert into report (
             "dco": {
                 "passed": true
             },
-            "ga4": {
+            "analytics": {
                 "passed": true
             },
             "github_discussions": {
@@ -348,7 +348,7 @@ insert into report (
             "dco": {
                 "passed": true
             },
-            "ga4": {
+            "analytics": {
                 "passed": true
             },
             "github_discussions": {
@@ -471,7 +471,7 @@ insert into report (
             "dco": {
                 "passed": false
             },
-            "ga4": {
+            "analytics": {
                 "passed": false
             },
             "github_discussions": {
@@ -571,7 +571,7 @@ select is(
                     "cla": 67,
                     "community_meeting": 0,
                     "dco": 67,
-                    "ga4": 67,
+                    "analytics": 67,
                     "github_discussions": 67,
                     "openssf_badge": 67,
                     "recent_release": 67,

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -50,8 +50,8 @@ Checks are organized in `check sets`. Each `check set` defines a number of check
   - Documentation / Readme
   - Documentation / Roadmap
   - Documentation / Website
+  - Best practices / Analytics
   - Best practices / Community meeting
-  - Best practices / Google Analytics 4
   - Best practices / GitHub discussions
   - Best practices / Slack presence
   - Security / Policy
@@ -359,6 +359,32 @@ This check passes if:
 
 ## Best practices
 
+### Analytics
+
+**ID**: `analytics`
+
+Projects websites should provide some web analytics.
+
+This check passes if:
+
+- A Google Analytics 3 (Universal Analytics) **Tracking ID** is found in the source of the website configured in Github. Regexps used:
+
+```sh
+"UA-[0-9]+-[0-9]+"
+```
+
+- A Google Analytics 4 **Measurement ID** is found in the source of the website configured in Github. Regexps used:
+
+```sh
+"G-[A-Z0-9]+"
+```
+
+- The HubSpot **tracking code** is found in the source of the website configured in Github. Regexps used:
+
+```sh
+"//js.hs-scripts.com/.+\.js"
+```
+
 ### Artifact Hub badge
 
 **ID**: `artifacthub_badge`
@@ -426,20 +452,6 @@ This check passes if:
 ```
 
 NOTE: *this check will be automatically marked as exempt if the CLA check passes and this one does not*.
-
-### Google Analytics 4
-
-**ID**: `ga4`
-
-Projects sites should migrate to Google Analytics 4.
-
-This check passes if:
-
-- A Google Analytics 4 **Measurement ID** is found in the source of the website configured in Github. Regexps used:
-
-```sh
-"G-[A-Z0-9]{8,10}"
-```
 
 ### GitHub discussions
 

--- a/web/src/data.tsx
+++ b/web/src/data.tsx
@@ -236,11 +236,11 @@ export const REPORT_OPTIONS: ReportOptionInfo = {
     ),
     reference: '/docs/topics/checks/#developer-certificate-of-origin',
   },
-  [ReportOption.GA4]: {
+  [ReportOption.Analytics]: {
     icon: <FaChartBar />,
-    name: 'Google Analytics 4',
-    legend: <span>Projects should migrate to Google Analytics 4</span>,
-    reference: '/docs/topics/checks/#google-analytics-4',
+    name: 'Analytics',
+    legend: <span>Projects websites should provide some web analytics</span>,
+    reference: '/docs/topics/checks/#analytics',
   },
   [ReportOption.GithubDiscussions]: {
     icon: <GoCommentDiscussion />,
@@ -404,11 +404,11 @@ export const CHECKS_PER_CATEGORY: ChecksPerCategory = {
   ],
   [ScoreType.License]: [ReportOption.SPDX, ReportOption.ApprovedLicense, ReportOption.LicenseScanning],
   [ScoreType.BestPractices]: [
+    ReportOption.Analytics,
     ReportOption.ArtifactHubBadge,
     ReportOption.CLA,
     ReportOption.CommunityMeeting,
     ReportOption.DCO,
-    ReportOption.GA4,
     ReportOption.GithubDiscussions,
     ReportOption.OpenSSFBadge,
     ReportOption.RecentRelease,

--- a/web/src/layout/detail/report/OptionCell.test.tsx
+++ b/web/src/layout/detail/report/OptionCell.test.tsx
@@ -68,6 +68,26 @@ describe('OptionCell', () => {
       expect(screen.getByText('LICENSE')).toBeInTheDocument();
     });
 
+    it('renders special Analytics option', () => {
+      render(
+        <table>
+          <tbody>
+            <OptionCell
+              label={ReportOption.Analytics}
+              check={{
+                passed: true,
+                value: ['GA3', 'GA4'],
+              }}
+            />
+          </tbody>
+        </table>
+      );
+
+      expect(screen.getByText(/GA3 | GA4/)).toBeInTheDocument();
+      expect(screen.getByText(/Projects websites should provide some web analytics/)).toBeInTheDocument();
+      expect(screen.getByText('Analytics')).toBeInTheDocument();
+    });
+
     it('renders option with url', () => {
       render(
         <table>

--- a/web/src/layout/detail/report/OptionCell.tsx
+++ b/web/src/layout/detail/report/OptionCell.tsx
@@ -54,10 +54,19 @@ const OptionCell = (props: Props) => {
     );
   };
 
-  const getCheckValue = (): string => {
+  const getCheckValue = (): string | JSX.Element => {
     switch (props.label) {
       case ReportOption.SPDX:
-        return props.check.value || 'Not detected';
+        return <>{isUndefined(props.check.value) ? 'Not detected' : (props.check.value as string)}</>;
+
+      case ReportOption.Analytics:
+        const values = isUndefined(props.check.value) ? [] : (props.check.value as string[]);
+        return (
+          <>
+            {opt.name}
+            {values.length > 0 && <span className="ms-2">({values.join(' · ')})</span>}
+          </>
+        );
 
       default:
         return opt.name;

--- a/web/src/layout/search/filters/checks/Block.test.tsx
+++ b/web/src/layout/search/filters/checks/Block.test.tsx
@@ -42,11 +42,11 @@ describe('Block', () => {
         screen.getByRole('button', { name: 'Mark all checks in Best Practices category as not passed' })
       ).toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Reset checks in Best Practices category' })).toBeInTheDocument();
+      expect(screen.getByText('Analytics')).toBeInTheDocument();
       expect(screen.getByText('Artifact Hub badge')).toBeInTheDocument();
       expect(screen.getByText('Contributor License Agreement')).toBeInTheDocument();
       expect(screen.getByText('Community meeting')).toBeInTheDocument();
       expect(screen.getByText('Developer Certificate of Origin')).toBeInTheDocument();
-      expect(screen.getByText('Google Analytics 4')).toBeInTheDocument();
       expect(screen.getByText('GitHub discussions')).toBeInTheDocument();
       expect(screen.getByText('OpenSSF badge')).toBeInTheDocument();
       expect(screen.getByText('Recent release')).toBeInTheDocument();
@@ -122,7 +122,7 @@ describe('Block', () => {
       const { rerender } = render(
         <Block
           {...defaultProps}
-          activePassingChecks={[ReportOption.CLA, ReportOption.GA4]}
+          activePassingChecks={[ReportOption.Analytics, ReportOption.CLA]}
           activeNotPassingChecks={[ReportOption.ArtifactHubBadge]}
         />
       );

--- a/web/src/layout/search/filters/checks/__snapshots__/Block.test.tsx.snap
+++ b/web/src/layout/search/filters/checks/__snapshots__/Block.test.tsx.snap
@@ -80,6 +80,105 @@ exports[`Block creates snapshot 1`] = `
               data-testid="elementWithTooltip"
             >
               <button
+                aria-label="Select Analytics as passed"
+                class="btn rounded-0 border p-0 btn passingBtn"
+                type="button"
+              >
+                <div
+                  class="d-flex align-items-center justify-content-center"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 12 16"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+              </button>
+            </div>
+          </div>
+          <div
+            class="d-none d-md-block position-relative undefined"
+          >
+            <div
+              class="cursorDefault"
+              data-testid="elementWithTooltip"
+            >
+              <button
+                aria-label="Select Analytics as not passed"
+                class="btn rounded-0 border p-0 btn"
+                type="button"
+              >
+                <div
+                  class="d-flex align-items-center justify-content-center"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    stroke="currentColor"
+                    stroke-width="0"
+                    viewBox="0 0 12 16"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+              </button>
+            </div>
+          </div>
+        </div>
+        <small
+          class="me-2"
+        >
+          <svg
+            fill="currentColor"
+            height="1em"
+            stroke="currentColor"
+            stroke-width="0"
+            viewBox="0 0 512 512"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M332.8 320h38.4c6.4 0 12.8-6.4 12.8-12.8V172.8c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v134.4c0 6.4 6.4 12.8 12.8 12.8zm96 0h38.4c6.4 0 12.8-6.4 12.8-12.8V76.8c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v230.4c0 6.4 6.4 12.8 12.8 12.8zm-288 0h38.4c6.4 0 12.8-6.4 12.8-12.8v-70.4c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v70.4c0 6.4 6.4 12.8 12.8 12.8zm96 0h38.4c6.4 0 12.8-6.4 12.8-12.8V108.8c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v198.4c0 6.4 6.4 12.8 12.8 12.8zM496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16z"
+            />
+          </svg>
+        </small>
+        <div
+          class="me-2"
+        >
+          Analytics
+        </div>
+      </div>
+    </span>
+    <span>
+      <div
+        class="d-flex flex-row align-items-center my-1"
+      >
+        <div
+          class="btn-group me-4 btns"
+          role="group"
+        >
+          <div
+            class="d-none d-md-block position-relative undefined"
+          >
+            <div
+              class="cursorDefault"
+              data-testid="elementWithTooltip"
+            >
+              <button
                 aria-label="Select Artifact Hub badge as passed"
                 class="btn rounded-0 border p-0 btn passingBtn"
                 type="button"
@@ -462,105 +561,6 @@ exports[`Block creates snapshot 1`] = `
           class="me-2"
         >
           Developer Certificate of Origin
-        </div>
-      </div>
-    </span>
-    <span>
-      <div
-        class="d-flex flex-row align-items-center my-1"
-      >
-        <div
-          class="btn-group me-4 btns"
-          role="group"
-        >
-          <div
-            class="d-none d-md-block position-relative undefined"
-          >
-            <div
-              class="cursorDefault"
-              data-testid="elementWithTooltip"
-            >
-              <button
-                aria-label="Select Google Analytics 4 as passed"
-                class="btn rounded-0 border p-0 btn passingBtn"
-                type="button"
-              >
-                <div
-                  class="d-flex align-items-center justify-content-center"
-                >
-                  <svg
-                    fill="currentColor"
-                    height="1em"
-                    stroke="currentColor"
-                    stroke-width="0"
-                    viewBox="0 0 12 16"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </div>
-          </div>
-          <div
-            class="d-none d-md-block position-relative undefined"
-          >
-            <div
-              class="cursorDefault"
-              data-testid="elementWithTooltip"
-            >
-              <button
-                aria-label="Select Google Analytics 4 as not passed"
-                class="btn rounded-0 border p-0 btn"
-                type="button"
-              >
-                <div
-                  class="d-flex align-items-center justify-content-center"
-                >
-                  <svg
-                    fill="currentColor"
-                    height="1em"
-                    stroke="currentColor"
-                    stroke-width="0"
-                    viewBox="0 0 12 16"
-                    width="1em"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"
-                      fill-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-              </button>
-            </div>
-          </div>
-        </div>
-        <small
-          class="me-2"
-        >
-          <svg
-            fill="currentColor"
-            height="1em"
-            stroke="currentColor"
-            stroke-width="0"
-            viewBox="0 0 512 512"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M332.8 320h38.4c6.4 0 12.8-6.4 12.8-12.8V172.8c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v134.4c0 6.4 6.4 12.8 12.8 12.8zm96 0h38.4c6.4 0 12.8-6.4 12.8-12.8V76.8c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v230.4c0 6.4 6.4 12.8 12.8 12.8zm-288 0h38.4c6.4 0 12.8-6.4 12.8-12.8v-70.4c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v70.4c0 6.4 6.4 12.8 12.8 12.8zm96 0h38.4c6.4 0 12.8-6.4 12.8-12.8V108.8c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v198.4c0 6.4 6.4 12.8 12.8 12.8zM496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16z"
-            />
-          </svg>
-        </small>
-        <div
-          class="me-2"
-        >
-          Google Analytics 4
         </div>
       </div>
     </span>

--- a/web/src/layout/stats/Checks.test.tsx
+++ b/web/src/layout/stats/Checks.test.tsx
@@ -4,11 +4,11 @@ import Checks from './Checks';
 
 const defaultProps = {
   data: {
+    analytics: 8,
     artifacthub_badge: 9,
     cla: 12,
     community_meeting: 43,
     dco: 83,
-    ga4: 8,
     openssf_badge: 59,
     recent_release: 81,
     slack_presence: 33,
@@ -33,6 +33,8 @@ describe('Checks', () => {
       render(<Checks {...defaultProps} />);
 
       expect(screen.getByText('Best Practices')).toBeInTheDocument();
+      expect(screen.getAllByText('Analytics')).toHaveLength(2);
+      expect(screen.getByText('8%')).toBeInTheDocument();
       expect(screen.getAllByText('Artifact Hub badge')).toHaveLength(2);
       expect(screen.getByText('9%')).toBeInTheDocument();
       expect(screen.getAllByText('CLA')).toHaveLength(2);
@@ -41,8 +43,6 @@ describe('Checks', () => {
       expect(screen.getByText('43%')).toBeInTheDocument();
       expect(screen.getAllByText('DCO')).toHaveLength(2);
       expect(screen.getByText('83%')).toBeInTheDocument();
-      expect(screen.getAllByText('Google Analytics 4')).toHaveLength(2);
-      expect(screen.getByText('8%')).toBeInTheDocument();
       expect(screen.getAllByText('OpenSSF badge')).toHaveLength(2);
       expect(screen.getByText('59%')).toBeInTheDocument();
       expect(screen.getAllByText('Recent release')).toHaveLength(2);

--- a/web/src/layout/stats/__snapshots__/Checks.test.tsx.snap
+++ b/web/src/layout/stats/__snapshots__/Checks.test.tsx.snap
@@ -23,6 +23,67 @@ exports[`Checks creates snapshot 1`] = `
             class="me-1 me-md-2 position-relative icon"
           >
             <svg
+              fill="currentColor"
+              height="1em"
+              stroke="currentColor"
+              stroke-width="0"
+              viewBox="0 0 512 512"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M332.8 320h38.4c6.4 0 12.8-6.4 12.8-12.8V172.8c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v134.4c0 6.4 6.4 12.8 12.8 12.8zm96 0h38.4c6.4 0 12.8-6.4 12.8-12.8V76.8c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v230.4c0 6.4 6.4 12.8 12.8 12.8zm-288 0h38.4c6.4 0 12.8-6.4 12.8-12.8v-70.4c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v70.4c0 6.4 6.4 12.8 12.8 12.8zm96 0h38.4c6.4 0 12.8-6.4 12.8-12.8V108.8c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v198.4c0 6.4 6.4 12.8 12.8 12.8zM496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16z"
+              />
+            </svg>
+          </div>
+          <div
+            class="progressTitle"
+          >
+            <span
+              class="d-inline-block d-md-none"
+            >
+              Analytics
+            </span>
+            <span
+              class="d-none d-md-inline-block"
+            >
+              <button
+                class="btn btn-link p-0 btn"
+              >
+                Analytics
+              </button>
+            </span>
+          </div>
+          <div
+            class="flex-grow-1 ms-2"
+          >
+            <div
+              class="progress rounded-0 progress"
+            >
+              <div
+                class="progress-bar"
+                role="progressbar"
+                style="width: 8%;"
+              />
+            </div>
+          </div>
+          <div
+            class="ps-2 lh-1 text-end fw-bold lightText scoreWrapper"
+          >
+            8%
+          </div>
+        </div>
+      </div>
+      <div
+        class="d-flex flex-column wrapper"
+      >
+        <div
+          class="d-flex flex-row align-items-center progressWrapper"
+        >
+          <div
+            class="me-1 me-md-2 position-relative icon"
+          >
+            <svg
               fill="none"
               height="1em"
               stroke="currentColor"
@@ -259,67 +320,6 @@ exports[`Checks creates snapshot 1`] = `
             class="ps-2 lh-1 text-end fw-bold lightText scoreWrapper"
           >
             83%
-          </div>
-        </div>
-      </div>
-      <div
-        class="d-flex flex-column wrapper"
-      >
-        <div
-          class="d-flex flex-row align-items-center progressWrapper"
-        >
-          <div
-            class="me-1 me-md-2 position-relative icon"
-          >
-            <svg
-              fill="currentColor"
-              height="1em"
-              stroke="currentColor"
-              stroke-width="0"
-              viewBox="0 0 512 512"
-              width="1em"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M332.8 320h38.4c6.4 0 12.8-6.4 12.8-12.8V172.8c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v134.4c0 6.4 6.4 12.8 12.8 12.8zm96 0h38.4c6.4 0 12.8-6.4 12.8-12.8V76.8c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v230.4c0 6.4 6.4 12.8 12.8 12.8zm-288 0h38.4c6.4 0 12.8-6.4 12.8-12.8v-70.4c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v70.4c0 6.4 6.4 12.8 12.8 12.8zm96 0h38.4c6.4 0 12.8-6.4 12.8-12.8V108.8c0-6.4-6.4-12.8-12.8-12.8h-38.4c-6.4 0-12.8 6.4-12.8 12.8v198.4c0 6.4 6.4 12.8 12.8 12.8zM496 384H64V80c0-8.84-7.16-16-16-16H16C7.16 64 0 71.16 0 80v336c0 17.67 14.33 32 32 32h464c8.84 0 16-7.16 16-16v-32c0-8.84-7.16-16-16-16z"
-              />
-            </svg>
-          </div>
-          <div
-            class="progressTitle"
-          >
-            <span
-              class="d-inline-block d-md-none"
-            >
-              Google Analytics 4
-            </span>
-            <span
-              class="d-none d-md-inline-block"
-            >
-              <button
-                class="btn btn-link p-0 btn"
-              >
-                Google Analytics 4
-              </button>
-            </span>
-          </div>
-          <div
-            class="flex-grow-1 ms-2"
-          >
-            <div
-              class="progress rounded-0 progress"
-            >
-              <div
-                class="progress-bar"
-                role="progressbar"
-                style="width: 8%;"
-              />
-            </div>
-          </div>
-          <div
-            class="ps-2 lh-1 text-end fw-bold lightText scoreWrapper"
-          >
-            8%
           </div>
         </div>
       </div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -67,7 +67,7 @@ export interface ReportCheck {
   exemption_reason?: string;
   failed?: boolean;
   fail_reason?: string;
-  value?: string;
+  value?: string | string[];
   url?: string;
   details?: string;
 }
@@ -162,6 +162,7 @@ export enum CheckSet {
 
 export enum ReportOption {
   Adopters = 'adopters',
+  Analytics = 'analytics',
   ApprovedLicense = 'license_approved',
   ArtifactHubBadge = 'artifacthub_badge',
   BinaryArtifacts = 'binary_artifacts',
@@ -175,7 +176,6 @@ export enum ReportOption {
   DangerousWorkflow = 'dangerous_workflow',
   DependencyUpdateTool = 'dependency_update_tool',
   DCO = 'dco',
-  GA4 = 'ga4',
   GithubDiscussions = 'github_discussions',
   Governance = 'governance',
   LicenseScanning = 'license_scanning',


### PR DESCRIPTION
Check if the project's website listed on GitHub is using any of the
analytics providers checked. At the moment the following are supported:

- Google Analytics 3 (Universal Analytics)
- Google Analytics 4
- HubSpot

In addition to displaying if the check passes or not, the providers
detected, which can be multiple, are also displayed in the UI, CSV
export and the console output of the linter CLI tool.

This check replaces the Google Analytics 4 check.

Closes #470

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>
Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>
Co-authored-by: Sergio Castaño Arteaga <tegioz@icloud.com>
Co-authored-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>