### PR TITLE
Remove sdk projects from Kubewarden

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -1179,22 +1179,6 @@
       url: https://github.com/kubewarden/kwctl
       check_sets:
         - code
-    - name: policy-sdk-rust
-      url: https://github.com/kubewarden/policy-sdk-rust
-      check_sets:
-        - code
-    - name: policy-sdk-go
-      url: https://github.com/kubewarden/policy-sdk-go
-      check_sets:
-        - code
-    - name: policy-sdk-swift
-      url: https://github.com/kubewarden/policy-sdk-swift
-      check_sets:
-        - code
-    - name: policy-sdk-dotnet
-      url: https://github.com/kubewarden/policy-sdk-dotnet
-      check_sets:
-        - code
 - name: kudo
   display_name: KUDO
   description: Kubernetes Universal Declarative Operator


### PR DESCRIPTION
We would like to remove the sdks from Kubewarden.

We want to leave:
- kubewarden-controller (main repo)
- docs
- policy-server
- kwctl
