### PR TITLE
Track projects' repos updated from registrar asap

### DIFF
--- a/clomonitor-apiserver/src/middleware.rs
+++ b/clomonitor-apiserver/src/middleware.rs
@@ -28,7 +28,7 @@ pub(crate) async fn metrics_collector<B>(req: Request<B>, next: Next<B>) -> impl
     let response = next.run(req).await;
 
     // Collect some info from response and track metric if the path matches
-    // with an endpoint we'd like to monitor
+    // any of the endpoints we'd like to monitor
     if ENDPOINTS_TO_MONITOR.is_match(&path) {
         let duration = start.elapsed().as_secs_f64();
         let labels = [

--- a/database/migrations/functions/projects/register_project.sql
+++ b/database/migrations/functions/projects/register_project.sql
@@ -61,7 +61,8 @@ begin
         on conflict (project_id, url) do update
         set
             name = excluded.name,
-            check_sets = excluded.check_sets;
+            check_sets = excluded.check_sets,
+            digest = null;
     end loop;
 
     -- Delete repositories that are no longer available


### PR DESCRIPTION
At the moment when the checksets assigned to a repo are updated, the repo isn't tracked again until it changes or after 1 day, whatever happens first.

This change clears the repo's digest so that it's processed on the next tracker run, regardless if it has changed or not.

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>