### PR TITLE
Store and display check sets used to build report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "http",
  "lazy_static",
  "mockall",
+ "postgres-types",
  "regex",
  "reqwest",
  "serde",
@@ -1943,6 +1944,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15eb2c6e362923af47e13c23ca5afb859e83d54452c55b0b9ac763b8f7c1ac16"
 
 [[package]]
+name = "postgres-derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e76c801e97c9cf696097369e517785b98056e98b21149384c812febfc5912f2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "postgres-openssl"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,6 +1993,7 @@ checksum = "73d946ec7d256b04dfadc4e6a3292324e6f417124750fc5c0950f981b703a0f1"
 dependencies = [
  "bytes",
  "fallible-iterator",
+ "postgres-derive",
  "postgres-protocol",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ mime = "0.3.16"
 mockall = "0.11.2"
 openssl = { version = "0.10.42", features = ["vendored"] }
 postgres-openssl = "0.5.0"
+postgres-types = { version = "0.2.4", features = ["derive"] }
 predicates = "2.1.1"
 regex = "1.6.0"
 reqwest = "0.11.12"

--- a/clomonitor-core/Cargo.toml
+++ b/clomonitor-core/Cargo.toml
@@ -21,6 +21,7 @@ graphql_client = { workspace = true }
 http = { workspace = true }
 lazy_static = { workspace = true }
 mockall = { workspace = true }
+postgres-types = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/clomonitor-core/src/linter/mod.rs
+++ b/clomonitor-core/src/linter/mod.rs
@@ -9,6 +9,7 @@ use check::{
 use clap::ValueEnum;
 #[cfg(feature = "mocks")]
 use mockall::automock;
+use postgres_types::ToSql;
 use serde::Deserialize;
 use std::{path::PathBuf, sync::Arc};
 use which::which;
@@ -40,12 +41,17 @@ pub struct LinterInput {
 
 /// Check sets define a set of checks that will be run on a given repository.
 /// Multiple check sets can be assigned to a repository.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, ValueEnum, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, ValueEnum, Deserialize, ToSql)]
 #[serde(rename_all = "kebab-case")]
+#[postgres(name = "check_set")]
 pub enum CheckSet {
+    #[postgres(name = "code")]
     Code,
+    #[postgres(name = "code-lite")]
     CodeLite,
+    #[postgres(name = "community")]
     Community,
+    #[postgres(name = "docs")]
     Docs,
 }
 

--- a/database/migrations/functions/projects/get_project.sql
+++ b/database/migrations/functions/projects/get_project.sql
@@ -29,6 +29,7 @@ returns json as $$
                 'report', (
                     select json_build_object(
                         'report_id', report_id,
+                        'check_sets', check_sets,
                         'data', data,
                         'errors', errors,
                         'updated_at', floor(extract(epoch from updated_at))

--- a/database/migrations/schema/001_initial.sql
+++ b/database/migrations/schema/001_initial.sql
@@ -46,6 +46,7 @@ create table if not exists repository (
 
 create table if not exists report (
     report_id uuid primary key default gen_random_uuid(),
+    check_sets check_set[],
     data jsonb,
     errors text,
     created_at timestamptz default current_timestamp not null,

--- a/database/tests/functions/projects/get_project.sql
+++ b/database/tests/functions/projects/get_project.sql
@@ -61,11 +61,13 @@ insert into repository (
 );
 insert into report (
     report_id,
+    check_sets,
     data,
     updated_at,
     repository_id
 ) values (
     '5133b909-a5b3-4c24-87b1-16b02a955ffa',
+    '{code, community}',
     '{"k": "v"}',
     '2022-02-24 09:40:42.695654+01',
     '00000000-0000-0001-0000-000000000000'
@@ -92,6 +94,7 @@ select is(
                 "name": "artifact-hub",
                 "report": {
                     "report_id": "5133b909-a5b3-4c24-87b1-16b02a955ffa",
+                    "check_sets": ["code", "community"],
                     "data": {"k": "v"},
                     "updated_at": 1645692042
                 },

--- a/database/tests/schema/schema.sql
+++ b/database/tests/schema/schema.sql
@@ -38,6 +38,7 @@ select columns_are('project', array[
 ]);
 select columns_are('report', array[
     'report_id',
+    'check_sets',
     'data',
     'errors',
     'created_at',

--- a/web/src/layout/detail/repositories/Summary.tsx
+++ b/web/src/layout/detail/repositories/Summary.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { CATEGORY_ICONS } from '../../../data';
 import { Repository, ScoreType } from '../../../types';
+import getCheckSets from '../../../utils/getCheckSets';
 import CheckSetBadge from '../../common/badges/CheckSetBadge';
 import BadgeCell from './BadgeCell';
 import styles from './Summary.module.css';
@@ -70,6 +71,7 @@ const Summary = (props: Props) => {
         <tbody>
           {props.repositories.map((repo: Repository) => {
             if (isUndefined(repo.report)) return null;
+            const checkSets = getCheckSets(repo);
             return (
               <tr key={`summary_${repo.repository_id}`}>
                 <td className={`align-middle ${styles.repoCell} ${styles.darkBgCell}`}>
@@ -81,7 +83,7 @@ const Summary = (props: Props) => {
                     >
                       {repo.name}
                     </button>
-                    <CheckSetBadge checkSets={repo.check_sets} className="d-none d-xl-inline-flex" />
+                    <CheckSetBadge checkSets={checkSets} className="d-none d-xl-inline-flex" />
                   </div>
                 </td>
 

--- a/web/src/layout/detail/repositories/index.tsx
+++ b/web/src/layout/detail/repositories/index.tsx
@@ -8,6 +8,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { CATEGORY_ICONS } from '../../../data';
 import { CheckSet, Repository, ScoreType } from '../../../types';
+import getCheckSets from '../../../utils/getCheckSets';
 import sortRepos from '../../../utils/sortRepos';
 import CheckSetBadge from '../../common/badges/CheckSetBadge';
 import ExternalLink from '../../common/ExternalLink';
@@ -91,6 +92,7 @@ const RepositoriesList = (props: Props) => {
 
       {repositories.map((repo: Repository) => {
         if (isUndefined(repo.report)) return null;
+        const checkSets = getCheckSets(repo);
         return (
           <div
             data-testid="repository-info"
@@ -105,7 +107,7 @@ const RepositoriesList = (props: Props) => {
                   <div className="d-none d-md-block">
                     <div className={`d-inline-flex flex-row align-items-center h4 fw-bold mb-2 ${styles.titleWrapper}`}>
                       <div className="text-truncate">{repo.name}</div>
-                      <CheckSetBadge checkSets={repo.check_sets} className={`ms-2 ${styles.checkSetBadge}`} />
+                      <CheckSetBadge checkSets={checkSets} className={`ms-2 ${styles.checkSetBadge}`} />
                       {getAnchorLink(repo.name)}
                     </div>
                     <ExternalLink href={repo.url}>
@@ -122,7 +124,7 @@ const RepositoriesList = (props: Props) => {
                       </ExternalLink>
                       {getAnchorLink(repo.name)}
                     </div>
-                    <CheckSetBadge checkSets={repo.check_sets} />
+                    <CheckSetBadge checkSets={checkSets} />
                   </div>
                 </div>
                 <div className="ms-3 ms-md-0 me-0 me-md-3">
@@ -159,7 +161,7 @@ const RepositoriesList = (props: Props) => {
                     score={!isUndefined(repo.score) ? repo.score.documentation : undefined}
                     referenceUrl="/docs/topics/checks/#documentation"
                     recommendedTemplates={
-                      repo.check_sets && repo.check_sets.includes(CheckSet.Community)
+                      checkSets.includes(CheckSet.Community)
                         ? [
                             {
                               name: 'CONTRIBUTING.md',

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -38,6 +38,7 @@ export interface Repository extends BaseRepository {
 
 export interface Report {
   data?: CoreReport | any;
+  check_sets?: CheckSet[];
   errors?: string | null;
   report_id: string;
   updated_at: number;

--- a/web/src/utils/getCheckSets.tsx
+++ b/web/src/utils/getCheckSets.tsx
@@ -1,0 +1,10 @@
+import { CheckSet, Repository } from '../types';
+
+const getCheckSets = (repo: Repository): CheckSet[] => {
+  if (repo.report && repo.report.check_sets) {
+    return repo.report.check_sets;
+  }
+  return repo.check_sets || [];
+};
+
+export default getCheckSets;

--- a/web/src/utils/sortRepos.tsx
+++ b/web/src/utils/sortRepos.tsx
@@ -1,6 +1,7 @@
-import { isUndefined, orderBy } from 'lodash';
+import { orderBy } from 'lodash';
 
 import { CheckSet, Repository } from '../types';
+import getCheckSets from './getCheckSets';
 
 // Sort by community repo kind, score global and alphabetically
 const sortRepos = (repos: Repository[]): Repository[] => {
@@ -8,8 +9,10 @@ const sortRepos = (repos: Repository[]): Repository[] => {
     repos,
     [
       (repo: Repository) => {
-        if (isUndefined(repo.check_sets)) return 0;
-        return repo.check_sets.includes(CheckSet.Community) ? -1 : 1;
+        const checkSets = getCheckSets(repo);
+
+        if (checkSets.length === 0) return 0;
+        return checkSets.includes(CheckSet.Community) ? -1 : 1;
       },
       'score.global',
       'name',


### PR DESCRIPTION
When the repository's check sets field is updated, until it's tracked again (max 1hr), we display the previous repository's report with the new check sets. This may lead to confusions as for that short period of time they won't match.

This change fixes that by storing and displaying the check sets used when the report was created. As soon as the repository is tracked again, the new check sets will be used to produce the report and they will be displayed in the UI.

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>
Signed-off-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>
Co-authored-by: Sergio Castaño Arteaga <tegioz@icloud.com>
Co-authored-by: Cintia Sanchez Garcia <cynthiasg@icloud.com>