### PR TITLE
Removed deprecated flux repo

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -727,10 +727,6 @@
       url: https://github.com/fluxcd/community
       check_sets:
         - community
-    - name: flux
-      url: https://github.com/fluxcd/flux
-      check_sets:
-        - code-lite
     - name: flux2
       url: https://github.com/fluxcd/flux2
       check_sets:


### PR DESCRIPTION
Flux v1 is deprecated and soon to be archived, so the maintainers have [requested that it not be monitored](https://github.com/fluxcd/flux2/issues/3212#issuecomment-1279693905).

Signed-off-by: Eddie Knight <iv.eddieknight@gmail.com>