### PR TITLE
Create snapshots of projects data periodically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,11 @@ updates:
       - dependency-name: "node"
         versions: ["18-alpine3.16", "19-alpine3.16"]
   - package-ecosystem: "docker"
+    directory: "/clomonitor-archiver"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+  - package-ecosystem: "docker"
     directory: "/clomonitor-linter"
     schedule:
       interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,55 @@ jobs:
           docker build -f clomonitor-apiserver/Dockerfile -t $ECR_REGISTRY/apiserver:$GITHUB_SHA .
           docker push $ECR_REGISTRY/apiserver:$GITHUB_SHA
 
+  build-archiver-image:
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - linter-backend
+      - tests-database
+      - tests-backend
+      - tests-frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-2
+      - name: Login to AWS ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Build and push image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          docker build -f clomonitor-archiver/Dockerfile -t $ECR_REGISTRY/archiver:$GITHUB_SHA .
+          docker push $ECR_REGISTRY/archiver:$GITHUB_SHA
+
+  build-linter-image:
+    if: github.ref == 'refs/heads/main'
+    needs:
+      - linter-backend
+      - tests-database
+      - tests-backend
+      - tests-frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Login to AWS Public ECR
+        uses: docker/login-action@v2
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Build and push image
+        run: |
+          docker build -f clomonitor-linter/Dockerfile -t public.ecr.aws/g6m3a0y9/linter:latest .
+          docker push public.ecr.aws/g6m3a0y9/linter:latest
+
   build-registrar-image:
     if: github.ref == 'refs/heads/main'
     needs:
@@ -201,25 +250,3 @@ jobs:
         run: |
           docker build -f clomonitor-tracker/Dockerfile -t $ECR_REGISTRY/tracker:$GITHUB_SHA .
           docker push $ECR_REGISTRY/tracker:$GITHUB_SHA
-
-  build-linter-image:
-    if: github.ref == 'refs/heads/main'
-    needs:
-      - linter-backend
-      - tests-database
-      - tests-backend
-      - tests-frontend
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Login to AWS Public ECR
-        uses: docker/login-action@v2
-        with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - name: Build and push image
-        run: |
-          docker build -f clomonitor-linter/Dockerfile -t public.ecr.aws/g6m3a0y9/linter:latest .
-          docker push public.ecr.aws/g6m3a0y9/linter:latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "clomonitor-archiver"
+version = "0.7.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "config",
+ "deadpool-postgres",
+ "openssl",
+ "postgres-openssl",
+ "serde_json",
+ "time",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "clomonitor-core"
 version = "0.7.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "clomonitor-apiserver",
+    "clomonitor-archiver",
     "clomonitor-core",
     "clomonitor-linter",
     "clomonitor-registrar",

--- a/chart/templates/archiver_cronjob.yaml
+++ b/chart/templates/archiver_cronjob.yaml
@@ -1,0 +1,47 @@
+{{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" }}
+apiVersion: batch/v1
+{{- else }}
+apiVersion: batch/v1beta1
+{{- end }}
+kind: CronJob
+metadata:
+  name: {{ include "chart.resourceNamePrefix" . }}archiver
+spec:
+  schedule: "0 * * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+        {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+          restartPolicy: Never
+          initContainers:
+          - name: check-db-ready
+            image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+            imagePullPolicy: {{ .Values.pullPolicy }}
+            env:
+              - name: PGHOST
+                value: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
+              - name: PGPORT
+                value: "{{ .Values.db.port }}"
+            command: ['sh', '-c', 'until pg_isready; do echo waiting for database; sleep 2; done;']
+          containers:
+          - name: archiver
+            image: {{ .Values.archiver.cronjob.image.repository }}:{{ .Values.imageTag | default (printf "v%s" .Chart.AppVersion) }}
+            imagePullPolicy: {{ .Values.pullPolicy }}
+            resources:
+              {{- toYaml .Values.archiver.cronjob.resources | nindent 14 }}
+            volumeMounts:
+            - name: archiver-config
+              mountPath: {{ .Values.configDir | quote }}
+              readOnly: true
+            command: ['clomonitor-archiver', '-c', '{{ .Values.configDir }}/archiver.yaml']
+          volumes:
+          - name: archiver-config
+            secret:
+              secretName: {{ include "chart.resourceNamePrefix" . }}archiver-config

--- a/chart/templates/archiver_secret.yaml
+++ b/chart/templates/archiver_secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "chart.resourceNamePrefix" . }}archiver-config
+type: Opaque
+stringData:
+  archiver.yaml: |-
+    db:
+      host: {{ default (printf "%s-postgresql.%s" .Release.Name .Release.Namespace) .Values.db.host }}
+      port: {{ .Values.db.port }}
+      dbname: {{ .Values.db.dbname }}
+      user: {{ .Values.db.user }}
+      password: {{ .Values.db.password }}
+    log:
+      format: {{ .Values.log.format }}

--- a/chart/values-staging.yaml
+++ b/chart/values-staging.yaml
@@ -31,12 +31,19 @@ apiserver:
         cpu: 1
         memory: 1000Mi
 
+archiver:
+  cronjob:
+    resources:
+      requests:
+        cpu: 1
+        memory: 100Mi
+
 registrar:
   cronjob:
     resources:
       requests:
         cpu: 1
-        memory: 250Mi
+        memory: 100Mi
 
 tracker:
   cronjob:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -73,6 +73,14 @@ apiserver:
       repository: clomonitor/apiserver
     resources: {}
 
+# Archiver configuration
+archiver:
+  cronjob:
+    image:
+      # Archiver image repository (without the tag)
+      repository: clomonitor/archiver
+    resources: {}
+
 # Registrar configuration
 registrar:
   cronjob:

--- a/clomonitor-apiserver/src/handlers.rs
+++ b/clomonitor-apiserver/src/handlers.rs
@@ -158,7 +158,7 @@ pub(crate) async fn project(
 ) -> impl IntoResponse {
     // Get project from database
     let project = db
-        .project(&foundation, &project)
+        .project_data(&foundation, &project)
         .await
         .map_err(internal_error)?;
 

--- a/clomonitor-apiserver/src/router.rs
+++ b/clomonitor-apiserver/src/router.rs
@@ -308,7 +308,7 @@ mod tests {
     #[tokio::test]
     async fn project_found() {
         let mut db = MockDB::new();
-        db.expect_project()
+        db.expect_project_data()
             .with(eq(FOUNDATION), eq(PROJECT))
             .times(1)
             .returning(|_, _| {
@@ -343,7 +343,7 @@ mod tests {
     #[tokio::test]
     async fn project_not_found() {
         let mut db = MockDB::new();
-        db.expect_project()
+        db.expect_project_data()
             .with(eq(FOUNDATION), eq(PROJECT))
             .times(1)
             .returning(|_: &str, _: &str| Box::pin(future::ready(Ok(None))));

--- a/clomonitor-archiver/Cargo.toml
+++ b/clomonitor-archiver/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "clomonitor-archiver"
+description = "A tool that creates snapshots of projects' data periodically"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+clap = { workspace = true }
+config = { workspace = true }
+deadpool-postgres = { workspace = true }
+openssl = { workspace = true }
+postgres-openssl = { workspace = true }
+serde_json = { workspace = true }
+time = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["time"] }
+tokio-postgres = { workspace = true, features = ["with-time-0_3"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+uuid = { workspace = true }

--- a/clomonitor-archiver/Dockerfile
+++ b/clomonitor-archiver/Dockerfile
@@ -1,15 +1,15 @@
-# Build registrar
+# Build archiver
 FROM rust:1-alpine3.16 as builder
 RUN apk --no-cache add musl-dev perl make
 WORKDIR /clomonitor
 COPY Cargo.* ./
 COPY clomonitor-apiserver/Cargo.* clomonitor-apiserver
-COPY clomonitor-archiver/Cargo.* clomonitor-archiver
+COPY clomonitor-archiver clomonitor-archiver
 COPY clomonitor-core/Cargo.* clomonitor-core
 COPY clomonitor-linter/Cargo.* clomonitor-linter
+COPY clomonitor-registrar/Cargo.* clomonitor-registrar
 COPY clomonitor-tracker/Cargo.* clomonitor-tracker
-COPY clomonitor-registrar clomonitor-registrar
-WORKDIR /clomonitor/clomonitor-registrar
+WORKDIR /clomonitor/clomonitor-archiver
 RUN cargo build --release
 
 # Final stage
@@ -17,4 +17,4 @@ FROM alpine:3.16.2
 RUN apk --no-cache add ca-certificates git && addgroup -S clomonitor && adduser -S clomonitor -G clomonitor
 USER clomonitor
 WORKDIR /home/clomonitor
-COPY --from=builder /clomonitor/target/release/clomonitor-registrar /usr/local/bin
+COPY --from=builder /clomonitor/target/release/clomonitor-archiver /usr/local/bin

--- a/clomonitor-archiver/src/archiver.rs
+++ b/clomonitor-archiver/src/archiver.rs
@@ -1,0 +1,269 @@
+use crate::db::DynDB;
+use anyhow::{Context, Result};
+use time::{ext::NumericalDuration, Date, OffsetDateTime};
+use tracing::{debug, info, instrument};
+use uuid::Uuid;
+
+/// Process all projects, generating snapshots when needed and removing the
+/// ones that are no longer needed.
+#[instrument(skip_all, err)]
+pub(crate) async fn run(db: DynDB) -> Result<()> {
+    info!("started");
+
+    for project_id in db.projects_ids().await?.iter() {
+        process_project(db.clone(), project_id).await?;
+    }
+
+    info!("finished");
+    Ok(())
+}
+
+/// Process project provided, generating a snapshot for the current day when
+/// needed and cleaning up the ones no longer needed.
+#[instrument(fields(project_id = project_id.to_string()), skip_all, err)]
+async fn process_project(db: DynDB, project_id: &Uuid) -> Result<()> {
+    // Get project's snapshots
+    let snapshots = db
+        .project_snapshots(project_id)
+        .await
+        .context("error getting project snapshots")?;
+    let latest_snapshot_date = snapshots.first().map(|d| d.to_owned());
+
+    // Store new project's snapshot if needed
+    let today = OffsetDateTime::now_utc().date();
+    if latest_snapshot_date.unwrap_or(Date::MIN) < today {
+        let data = db
+            .project_data(project_id)
+            .await
+            .context("error getting project data")?;
+        if let Some(data) = data {
+            db.store_project_snapshot(project_id, data)
+                .await
+                .context("error storing project snapshot")?;
+            debug!("snapshot [{}] stored", today);
+        }
+    }
+
+    // Delete snapshots no longer needed
+    let snapshots_to_keep = get_snapshots_to_keep(today, snapshots.as_slice());
+    for snapshot in snapshots.iter() {
+        if !snapshots_to_keep.contains(snapshot) {
+            db.delete_project_snapshot(project_id, snapshot)
+                .await
+                .context(format!("error deleting snapshot {}", snapshot))?;
+            debug!("snapshot [{}] deleted", snapshot);
+        }
+    }
+
+    Ok(())
+}
+
+/// Return a list of snapshots that we'd like to keep.
+fn get_snapshots_to_keep(ref_date: Date, snapshots: &[Date]) -> Vec<Date> {
+    let mut snapshots_to_keep = Vec::new();
+
+    for snapshot in snapshots.iter().copied() {
+        // Include previous 2 days
+        if ref_date - snapshot <= 2.days() {
+            snapshots_to_keep.push(snapshot);
+            continue;
+        }
+
+        // Include latest snapshot for each week in the ref date month
+        if snapshot.month() == ref_date.month()
+            && snapshots_to_keep.last().map_or(true, |last_snapshot_kept| {
+                last_snapshot_kept.iso_week() > snapshot.iso_week()
+            })
+        {
+            snapshots_to_keep.push(snapshot);
+            continue;
+        }
+
+        // Include latest snapshot for each month in the ref date year
+        if snapshot.year() == ref_date.year()
+            && snapshots_to_keep.last().map_or(true, |last_snapshot_kept| {
+                last_snapshot_kept.month() as u8 > snapshot.month() as u8
+            })
+        {
+            snapshots_to_keep.push(snapshot);
+            continue;
+        }
+
+        // Include latest snapshot of the year for the rest of the years
+        if snapshots_to_keep.last().map_or(true, |last_snapshot_kept| {
+            last_snapshot_kept.year() > snapshot.year()
+        }) {
+            snapshots_to_keep.push(snapshot);
+        }
+    }
+
+    snapshots_to_keep
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::macros::date;
+
+    #[test]
+    fn get_snapshots_to_keep_1() {
+        assert_eq!(
+            get_snapshots_to_keep(
+                date!(2022 - 10 - 28),
+                &[
+                    date!(2022 - 10 - 28),
+                    date!(2022 - 10 - 27),
+                    date!(2022 - 10 - 26),
+                ]
+            ),
+            vec![
+                date!(2022 - 10 - 28),
+                date!(2022 - 10 - 27),
+                date!(2022 - 10 - 26),
+            ]
+        );
+    }
+
+    #[test]
+    fn get_snapshots_to_keep_2() {
+        assert_eq!(
+            get_snapshots_to_keep(
+                date!(2022 - 10 - 28),
+                &[
+                    date!(2022 - 10 - 28),
+                    date!(2022 - 10 - 25),
+                    date!(2022 - 10 - 24),
+                ]
+            ),
+            vec![date!(2022 - 10 - 28)]
+        );
+    }
+
+    #[test]
+    fn get_snapshots_to_keep_3() {
+        assert_eq!(
+            get_snapshots_to_keep(
+                date!(2022 - 10 - 24),
+                &[
+                    date!(2022 - 10 - 24),
+                    date!(2022 - 10 - 20),
+                    date!(2022 - 10 - 19),
+                ]
+            ),
+            vec![date!(2022 - 10 - 24), date!(2022 - 10 - 20),]
+        );
+    }
+
+    #[test]
+    fn get_snapshots_to_keep_4() {
+        assert_eq!(
+            get_snapshots_to_keep(
+                date!(2022 - 10 - 25),
+                &[
+                    date!(2022 - 10 - 25),
+                    date!(2022 - 10 - 24),
+                    date!(2022 - 10 - 20),
+                    date!(2022 - 10 - 19),
+                    date!(2022 - 10 - 13),
+                    date!(2022 - 10 - 10),
+                ]
+            ),
+            vec![
+                date!(2022 - 10 - 25),
+                date!(2022 - 10 - 24),
+                date!(2022 - 10 - 20),
+                date!(2022 - 10 - 13),
+            ]
+        );
+    }
+
+    #[test]
+    fn get_snapshots_to_keep_5() {
+        assert_eq!(
+            get_snapshots_to_keep(
+                date!(2022 - 10 - 25),
+                &[
+                    date!(2022 - 10 - 25),
+                    date!(2022 - 10 - 13),
+                    date!(2022 - 10 - 10),
+                ]
+            ),
+            vec![date!(2022 - 10 - 25), date!(2022 - 10 - 13),]
+        );
+    }
+
+    #[test]
+    fn get_snapshots_to_keep_6() {
+        assert_eq!(
+            get_snapshots_to_keep(
+                date!(2022 - 10 - 25),
+                &[
+                    date!(2022 - 10 - 18),
+                    date!(2022 - 10 - 17),
+                    date!(2022 - 9 - 29),
+                    date!(2022 - 9 - 11),
+                    date!(2022 - 8 - 1),
+                ]
+            ),
+            vec![
+                date!(2022 - 10 - 18),
+                date!(2022 - 9 - 29),
+                date!(2022 - 8 - 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn get_snapshots_to_keep_7() {
+        assert_eq!(
+            get_snapshots_to_keep(
+                date!(2022 - 10 - 25),
+                &[
+                    date!(2022 - 10 - 18),
+                    date!(2021 - 10 - 17),
+                    date!(2021 - 9 - 29),
+                    date!(2020 - 9 - 11),
+                    date!(2020 - 8 - 1),
+                ]
+            ),
+            vec![
+                date!(2022 - 10 - 18),
+                date!(2021 - 10 - 17),
+                date!(2020 - 9 - 11),
+            ]
+        );
+    }
+
+    #[test]
+    fn get_snapshots_to_keep_8() {
+        assert_eq!(
+            get_snapshots_to_keep(
+                date!(2022 - 10 - 25),
+                &[
+                    date!(2022 - 10 - 25),
+                    date!(2022 - 10 - 24),
+                    date!(2022 - 10 - 20),
+                    date!(2022 - 10 - 19),
+                    date!(2022 - 10 - 13),
+                    date!(2022 - 10 - 10),
+                    date!(2022 - 7 - 1),
+                    date!(2022 - 6 - 2),
+                    date!(2022 - 6 - 1),
+                    date!(2021 - 9 - 29),
+                    date!(2020 - 9 - 11),
+                    date!(2020 - 8 - 1),
+                ]
+            ),
+            vec![
+                date!(2022 - 10 - 25),
+                date!(2022 - 10 - 24),
+                date!(2022 - 10 - 20),
+                date!(2022 - 10 - 13),
+                date!(2022 - 7 - 1),
+                date!(2022 - 6 - 2),
+                date!(2021 - 9 - 29),
+                date!(2020 - 9 - 11),
+            ]
+        );
+    }
+}

--- a/clomonitor-archiver/src/db.rs
+++ b/clomonitor-archiver/src/db.rs
@@ -1,0 +1,100 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use deadpool_postgres::Pool;
+use serde_json::Value;
+use std::sync::Arc;
+use time::Date;
+use uuid::Uuid;
+
+/// Type alias to represent a DB trait object.
+pub(crate) type DynDB = Arc<dyn DB + Send + Sync>;
+
+/// Trait that defines some operations a DB implementation must support.
+#[async_trait]
+pub(crate) trait DB {
+    /// Delete the provided project's snapshot.
+    async fn delete_project_snapshot(&self, project_id: &Uuid, date: &Date) -> Result<()>;
+
+    /// Get project's data.
+    async fn project_data(&self, project_id: &Uuid) -> Result<Option<Value>>;
+
+    /// Get the dates of all the project's snapshots.
+    async fn project_snapshots(&self, project_id: &Uuid) -> Result<Vec<Date>>;
+
+    /// Get the ids of all projects registered in the database.
+    async fn projects_ids(&self) -> Result<Vec<Uuid>>;
+
+    /// Store the provided project's snapshot.
+    async fn store_project_snapshot(&self, project_id: &Uuid, data: Value) -> Result<()>;
+}
+
+/// DB implementation backed by PostgreSQL.
+pub(crate) struct PgDB {
+    pool: Pool,
+}
+
+impl PgDB {
+    /// Create a new PgDB instance.
+    pub(crate) fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl DB for PgDB {
+    async fn delete_project_snapshot(&self, project_id: &Uuid, date: &Date) -> Result<()> {
+        let db = self.pool.get().await?;
+        match db
+            .execute(
+                "delete from project_snapshot where project_id = $1 and date = $2",
+                &[&project_id, &date],
+            )
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    async fn project_data(&self, project_id: &Uuid) -> Result<Option<Value>> {
+        let db = self.pool.get().await?;
+        let row = db
+            .query_one("select get_project_by_id($1::uuid)", &[&project_id])
+            .await?;
+        let data: Option<Value> = row.get(0);
+        Ok(data)
+    }
+
+    async fn project_snapshots(&self, project_id: &Uuid) -> Result<Vec<Date>> {
+        let db = self.pool.get().await?;
+        let rows = db
+            .query(
+                "select date from project_snapshot where project_id = $1 order by date desc",
+                &[&project_id],
+            )
+            .await?;
+        let snapshots = rows.iter().map(|row| row.get(0)).collect();
+        Ok(snapshots)
+    }
+
+    async fn projects_ids(&self) -> Result<Vec<Uuid>> {
+        let db = self.pool.get().await?;
+        let rows = db.query("select project_id from project", &[]).await?;
+        let projects = rows.iter().map(|row| row.get(0)).collect();
+        Ok(projects)
+    }
+
+    async fn store_project_snapshot(&self, project_id: &Uuid, data: Value) -> Result<()> {
+        let db = self.pool.get().await?;
+        match db
+            .execute(
+                "insert into project_snapshot (project_id, data) values ($1::uuid, $2::jsonb)",
+                &[&project_id, &data],
+            )
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err.into()),
+        }
+    }
+}

--- a/clomonitor-archiver/src/main.rs
+++ b/clomonitor-archiver/src/main.rs
@@ -1,0 +1,56 @@
+use crate::db::PgDB;
+use anyhow::{Context, Result};
+use clap::Parser;
+use config::{Config, File};
+use deadpool_postgres::{Config as DbConfig, Runtime};
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
+use postgres_openssl::MakeTlsConnector;
+use std::{path::PathBuf, sync::Arc};
+use tracing::debug;
+use tracing_subscriber::EnvFilter;
+
+mod archiver;
+mod db;
+
+#[derive(Debug, Parser)]
+#[clap(author, version, about)]
+struct Args {
+    /// Config file path
+    #[clap(short, long)]
+    config: PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // Setup configuration
+    let cfg = Config::builder()
+        .add_source(File::from(args.config))
+        .build()
+        .context("error setting up configuration")?;
+
+    // Setup logging
+    if std::env::var_os("RUST_LOG").is_none() {
+        std::env::set_var("RUST_LOG", "clomonitor_archiver=debug")
+    }
+    let s = tracing_subscriber::fmt().with_env_filter(EnvFilter::from_default_env());
+    match cfg.get_string("log.format").as_deref() {
+        Ok("json") => s.json().init(),
+        _ => s.init(),
+    };
+
+    // Setup database
+    debug!("setting up database");
+    let mut builder = SslConnector::builder(SslMethod::tls())?;
+    builder.set_verify(SslVerifyMode::NONE);
+    let connector = MakeTlsConnector::new(builder.build());
+    let db_cfg: DbConfig = cfg.get("db")?;
+    let pool = db_cfg.create_pool(Some(Runtime::Tokio1), connector)?;
+    let db = Arc::new(PgDB::new(pool));
+
+    // Run archiver
+    archiver::run(db).await?;
+
+    Ok(())
+}

--- a/clomonitor-linter/Dockerfile
+++ b/clomonitor-linter/Dockerfile
@@ -4,10 +4,11 @@ RUN apk --no-cache add musl-dev perl make
 WORKDIR /clomonitor
 COPY Cargo.* ./
 COPY clomonitor-apiserver/Cargo.* clomonitor-apiserver
-COPY clomonitor-registrar/Cargo.* clomonitor-registrar
-COPY clomonitor-tracker/Cargo.* clomonitor-tracker
+COPY clomonitor-archiver/Cargo.* clomonitor-archiver
 COPY clomonitor-core clomonitor-core
 COPY clomonitor-linter clomonitor-linter
+COPY clomonitor-registrar/Cargo.* clomonitor-registrar
+COPY clomonitor-tracker/Cargo.* clomonitor-tracker
 WORKDIR /clomonitor/clomonitor-linter
 RUN cargo build --release
 

--- a/clomonitor-tracker/Dockerfile
+++ b/clomonitor-tracker/Dockerfile
@@ -4,9 +4,10 @@ RUN apk --no-cache add musl-dev perl make
 WORKDIR /clomonitor
 COPY Cargo.* ./
 COPY clomonitor-apiserver/Cargo.* clomonitor-apiserver
-COPY clomonitor-registrar/Cargo.* clomonitor-registrar
+COPY clomonitor-archiver/Cargo.* clomonitor-archiver
 COPY clomonitor-core clomonitor-core
 COPY clomonitor-linter clomonitor-linter
+COPY clomonitor-registrar/Cargo.* clomonitor-registrar
 COPY clomonitor-tracker clomonitor-tracker
 WORKDIR /clomonitor/clomonitor-tracker
 RUN cargo build --release

--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -1,4 +1,5 @@
-{{ template "projects/get_project.sql" }}
+{{ template "projects/get_project_by_id.sql" }}
+{{ template "projects/get_project_by_name.sql" }}
 {{ template "projects/get_project_checks.sql" }}
 {{ template "projects/get_project_passed_checks.sql" }}
 {{ template "projects/register_project.sql" }}

--- a/database/migrations/functions/projects/get_project_by_name.sql
+++ b/database/migrations/functions/projects/get_project_by_name.sql
@@ -1,0 +1,11 @@
+-- Returns some information about a project in json format.
+create or replace function get_project_by_name(
+    p_foundation text,
+    p_project_name text
+)
+returns json as $$
+    select get_project_by_id(p.project_id)
+    from project p
+    where p.foundation_id = p_foundation
+    and p.name = p_project_name;
+$$ language sql;

--- a/database/migrations/schema/001_initial.sql
+++ b/database/migrations/schema/001_initial.sql
@@ -54,3 +54,10 @@ create table if not exists report (
     repository_id uuid not null references repository on delete cascade,
     unique (repository_id)
 );
+
+create table if not exists project_snapshot (
+    project_id uuid not null references project on delete cascade,
+    date date default current_date not null,
+    data jsonb,
+    primary key (project_id, date)
+);

--- a/database/tests/functions/projects/get_project_by_id.sql
+++ b/database/tests/functions/projects/get_project_by_id.sql
@@ -1,0 +1,138 @@
+-- Start transaction and plan tests
+begin;
+select plan(2);
+
+-- Non existing project
+select is(
+    get_project_by_id('00000000-0001-0000-0000-000000000000')::jsonb,
+    (null::jsonb),
+    'Null is returned if the requested project does not exist'
+);
+
+-- Seed some data
+insert into foundation values ('cncf', 'CNCF', 'http://127.0.0.1:8080/cncf.yaml');
+insert into project (
+    project_id,
+    name,
+    display_name,
+    description,
+    category,
+    home_url,
+    logo_url,
+    devstats_url,
+    score,
+    rating,
+    accepted_at,
+    updated_at,
+    maturity,
+    foundation_id
+) values (
+    '00000000-0001-0000-0000-000000000000',
+    'artifact-hub',
+    'Artifact Hub',
+    'Artifact Hub is a web-based application that enables finding, installing, and publishing packages and configurations for CNCF projects.',
+    'category1',
+    'https://artifacthub.io',
+    'https://raw.githubusercontent.com/cncf/artwork/master/projects/artifacthub/icon/color/artifacthub-icon-color.svg',
+    'https://artifacthub.devstats.cncf.io/',
+    '{"k": "v"}',
+    'a',
+    '2021-01-01',
+    '2022-02-24 09:40:42.695654+01',
+    'sandbox',
+    'cncf'
+);
+insert into repository (
+    repository_id,
+    name,
+    url,
+    check_sets,
+    digest,
+    score,
+    project_id
+) values (
+    '00000000-0000-0001-0000-000000000000',
+    'artifact-hub',
+    'https://github.com/artifacthub/hub',
+    '{code, community}',
+    '653b5219d16a2e5be274a7fb765916789ae68fbb',
+    '{"k": "v"}',
+    '00000000-0001-0000-0000-000000000000'
+);
+insert into report (
+    report_id,
+    check_sets,
+    data,
+    updated_at,
+    repository_id
+) values (
+    '5133b909-a5b3-4c24-87b1-16b02a955ffa',
+    '{code, community}',
+    '{"k": "v"}',
+    '2022-02-24 09:40:42.695654+01',
+    '00000000-0000-0001-0000-000000000000'
+);
+insert into project_snapshot (
+    project_id,
+    date,
+    data
+) values (
+    '00000000-0001-0000-0000-000000000000',
+    '2022-01-01',
+    '{"k": "v"}'
+);
+insert into project_snapshot (
+    project_id,
+    date,
+    data
+) values (
+    '00000000-0001-0000-0000-000000000000',
+    '2022-01-02',
+    '{"k": "v"}'
+);
+
+-- Run some tests
+select is(
+    get_project_by_id('00000000-0001-0000-0000-000000000000')::jsonb,
+    '{
+        "category": "category1",
+        "description": "Artifact Hub is a web-based application that enables finding, installing, and publishing packages and configurations for CNCF projects.",
+        "devstats_url": "https://artifacthub.devstats.cncf.io/",
+        "display_name": "Artifact Hub",
+        "home_url": "https://artifacthub.io",
+        "id": "00000000-0001-0000-0000-000000000000",
+        "logo_url": "https://raw.githubusercontent.com/cncf/artwork/master/projects/artifacthub/icon/color/artifacthub-icon-color.svg",
+        "maturity": "sandbox",
+        "name": "artifact-hub",
+        "rating": "a",
+        "repositories": [
+            {
+                "digest": "653b5219d16a2e5be274a7fb765916789ae68fbb",
+                "check_sets": ["code", "community"],
+                "name": "artifact-hub",
+                "report": {
+                    "report_id": "5133b909-a5b3-4c24-87b1-16b02a955ffa",
+                    "check_sets": ["code", "community"],
+                    "data": {"k": "v"},
+                    "updated_at": 1645692042
+                },
+                "repository_id": "00000000-0000-0001-0000-000000000000",
+                "score": {"k": "v"},
+                "url": "https://github.com/artifacthub/hub"
+            }
+        ],
+        "score": {"k": "v"},
+        "snapshots": [
+            "2022-01-02",
+            "2022-01-01"
+        ],
+        "accepted_at": 1609459200,
+        "updated_at": 1645692042,
+        "foundation": "cncf"
+    }'::jsonb,
+    'Project returned as a json object'
+);
+
+-- Finish tests and rollback transaction
+select * from finish();
+rollback;

--- a/database/tests/functions/projects/get_project_by_name.sql
+++ b/database/tests/functions/projects/get_project_by_name.sql
@@ -4,7 +4,7 @@ select plan(2);
 
 -- Non existing project
 select is(
-    get_project('non-existing', 'non-existing')::jsonb,
+    get_project_by_name('non-existing', 'non-existing')::jsonb,
     (null::jsonb),
     'Null is returned if the requested project does not exist'
 );
@@ -75,7 +75,7 @@ insert into report (
 
 -- Run some tests
 select is(
-    get_project('cncf', 'artifact-hub')::jsonb,
+    get_project_by_name('cncf', 'artifact-hub')::jsonb,
     '{
         "category": "category1",
         "description": "Artifact Hub is a web-based application that enables finding, installing, and publishing packages and configurations for CNCF projects.",

--- a/database/tests/schema/schema.sql
+++ b/database/tests/schema/schema.sql
@@ -1,6 +1,6 @@
 -- Start transaction and plan tests
 begin;
-select plan(23);
+select plan(27);
 
 -- Check expected extension exist
 select has_extension('pgcrypto');
@@ -8,6 +8,7 @@ select has_extension('pgcrypto');
 -- Check expected tables exist
 select has_table('foundation');
 select has_table('project');
+select has_table('project_snapshot');
 select has_table('report');
 select has_table('repository');
 
@@ -35,6 +36,11 @@ select columns_are('project', array[
     'maturity',
     'digest',
     'foundation_id'
+]);
+select columns_are('project_snapshot', array[
+    'project_id',
+    'date',
+    'data'
 ]);
 select columns_are('report', array[
     'report_id',
@@ -65,6 +71,9 @@ select indexes_are('project', array[
     'project_pkey',
     'project_foundation_id_name_key'
 ]);
+select indexes_are('project_snapshot', array[
+    'project_snapshot_pkey'
+]);
 select indexes_are('report', array[
     'report_pkey',
     'report_repository_id_key'
@@ -76,7 +85,8 @@ select indexes_are('repository', array[
 
 -- Check expected functions exist
 -- Projects
-select has_function('get_project');
+select has_function('get_project_by_id');
+select has_function('get_project_by_name');
 select has_function('get_project_checks');
 select has_function('get_project_passed_checks');
 select has_function('register_project');

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,6 +11,7 @@ clomonitor
 ├── .github
 ├── chart
 ├── clomonitor-apiserver
+├── clomonitor-archiver
 ├── clomonitor-core
 ├── clomonitor-linter
 ├── clomonitor-registrar
@@ -25,6 +26,8 @@ clomonitor
 - **chart:** contains the CLOMonitor Helm chart, which is the recommended installation method.
 
 - **clomonitor-apiserver** contains the source code of the `apiserver` backend component.
+
+- **clomonitor-archiver** contains the source code of the `archiver` backend component.
 
 - **clomonitor-core:** contains the source code of the `core backend modules`, like linter and score.
 
@@ -84,7 +87,7 @@ It's composed of two modules:
 
 ## Backend applications
 
-The backend applications are `apiserver`, `registrar` and `tracker`. They are located in the `clomonitor-apiserver`, `clomonitor-registrar` and `clomonitor-tracker` directories respectively. Each of the applications' directory contains a `Dockerfile` that will be used to build the corresponding Docker image.
+The backend applications are `apiserver`, `archiver`, `registrar` and `tracker`. They are located in the `clomonitor-apiserver`, `clomonitor-archiver`, `clomonitor-registrar` and `clomonitor-tracker` directories respectively. Each of the applications' directory contains a `Dockerfile` that will be used to build the corresponding Docker image.
 
 ```sh
 .
@@ -93,6 +96,10 @@ The backend applications are `apiserver`, `registrar` and `tracker`. They are lo
 │   ├── Dockerfile
 │   ├── src
 │   └── templates
+├── clomonitor-archiver
+│   ├── Cargo.toml
+│   ├── Dockerfile
+│   └── src
 ├── clomonitor-registrar
 │   ├── Cargo.toml
 │   ├── Dockerfile
@@ -104,6 +111,8 @@ The backend applications are `apiserver`, `registrar` and `tracker`. They are lo
 ```
 
 - **apiserver:** this component provides an HTTP API that exposes some endpoints used by the web application layer, plus some extra functionality like badges configuration, reports summary, etc. It is also in charge of serving the web application static assets.
+
+- **archiver:** this component is in charge of creating snapshots of projects' data periodically. It's launched periodically from a Kubernetes [cronjob](https://github.com/cncf/clomonitor/blob/main/chart/templates/archiver_cronjob.yaml).
 
 - **registrar:** this component is in charge of registering the projects available on each foundation's data file in the database. It's launched periodically from a Kubernetes [cronjob](https://github.com/cncf/clomonitor/blob/main/chart/templates/registrar_cronjob.yaml).
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -6,6 +6,12 @@ docker build \
     -t clomonitor/apiserver \
 .
 
+# archiver
+docker build \
+    -f clomonitor-archiver/Dockerfile \
+    -t clomonitor/archiver \
+.
+
 # dbmigrator
 docker build \
     -f database/migrations/Dockerfile \


### PR DESCRIPTION
A new component named `archiver` has been added to CLOMonitor. This component takes snapshots of the projects data periodically and cleans up snapshots that are no longer needed. Snapshots available are now returned when fetching the project's data.

This is some ground work in preparation for the `Time Machine` feature.

Related to #681

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>