### PR TITLE
fix: update trademark_disclaimer to allow for new URL

### DIFF
--- a/clomonitor-core/src/linter/checks/trademark_disclaimer.rs
+++ b/clomonitor-core/src/linter/checks/trademark_disclaimer.rs
@@ -19,7 +19,7 @@ pub(crate) const CHECK_SETS: [CheckSet; 1] = [CheckSet::Community];
 lazy_static! {
     #[rustfmt::skip]
     pub(crate) static ref TRADEMARK_DISCLAIMER: RegexSet = RegexSet::new(vec![
-        r"https://(?:w{3}\.)?linuxfoundation.org/trademark-usage",
+        r"https://(?:w{3}\.)?linuxfoundation.org/(?:legal/)?trademark-usage",
         r"The Linux Foundation.* has registered trademarks and uses trademarks",
     ]).expect("exprs in TRADEMARK_DISCLAIMER to be valid");
 }
@@ -45,7 +45,11 @@ mod tests {
     #[test]
     fn trademark_disclaimer_match() {
         assert!(TRADEMARK_DISCLAIMER.is_match("https://www.linuxfoundation.org/trademark-usage"));
+        assert!(
+            TRADEMARK_DISCLAIMER.is_match("https://www.linuxfoundation.org/legal/trademark-usage")
+        );
         assert!(TRADEMARK_DISCLAIMER.is_match("https://linuxfoundation.org/trademark-usage"));
+        assert!(TRADEMARK_DISCLAIMER.is_match("https://linuxfoundation.org/legal/trademark-usage"));
         assert!(TRADEMARK_DISCLAIMER.is_match(
             "The Linux Foundation® (TLF) has registered trademarks and uses trademarks."
         ));

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -624,6 +624,6 @@ This check passes if:
 - The Linux Foundation trademark disclaimer is found in the content of the website configured in Github. Regexps used:
 
 ```sh
-"https://(?:w{3}\.)?linuxfoundation.org/trademark-usage"
+"https://(?:w{3}\.)?linuxfoundation.org/(?:legal/)?trademark-usage"
 "The Linux Foundation.* has registered trademarks and uses trademarks"
 ```


### PR DESCRIPTION
In order to account for The Linux Foundation's new `/legal/trademark-usage` route, this regex on line 22 adds an optional `legal/` capture group.

I've also added tests and docs, and run `rustfmt`.

Review and feedback appreciated. 🙇

Addresses comments in https://github.com/cncf/clomonitor/issues/33.

Signed-off-by: Matthew Pereira <mail@matthewpereira.com>