### PR TITLE
Create snapshots of stats data periodically

### DIFF
--- a/database/migrations/schema/004_archive_stats.sql
+++ b/database/migrations/schema/004_archive_stats.sql
@@ -1,0 +1,10 @@
+create table if not exists stats_snapshot (
+    foundation_id text references foundation on delete cascade,
+    date date not null default current_date,
+    data jsonb,
+    unique (foundation_id, date)
+);
+
+---- create above / drop below ----
+
+drop table if exists stats_snapshot;


### PR DESCRIPTION
The end goal is to display a timeline in the stats page, similar to the one we have on each project, that allows visualizing stats at some point in the past.

Signed-off-by: Sergio Castaño Arteaga <tegioz@icloud.com>