### PR TITLE
adding vitess website repo to cncf dataset

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -2164,6 +2164,10 @@
       check_sets:
         - community
         - code
+    - name: website
+      url: https://github.com/vitessio/website/
+      check_sets:
+        - docs
 - name: volcano
   display_name: Volcano
   description: A Kubernetes native system for high-performance workloads


### PR DESCRIPTION
Adding Vitess website repo to CNCF dataset to address CLOTributor issue https://github.com/cncf/clotributor/issues/154

Signed-off-by: Nate W <natew@cncf.io>