### PR TITLE
Add CNCF tags to CLOTributor

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -2998,3 +2998,63 @@
       url: https://github.com/cncf/tag-security
       exclude:
         - clomonitor
+- name: cncf-tag-storage
+  display_name: TAG Storage
+  description: CNCF Technical Advisory Group for Storage
+  logo_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-storage/icon/color/tag-storage-icon-color.svg
+  logo_dark_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-storage/icon/white/tag-storage-icon-white.svg
+  repositories:
+    - name: tag-storage
+      url: https://github.com/cncf/tag-storage
+      exclude:
+        - clomonitor
+- name: cncf-tag-app-delivery
+  display_name: TAG App Delivery
+  description: CNCF Technical Advisory Group for App Delivery
+  logo_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-app-delivery/icon/color/tag-app-delivery-icon-color.svg
+  logo_dark_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-app-delivery/icon/white/tag-app-delivery-icon-white.svg
+  repositories:
+    - name: tag-app-delivery
+      url: https://github.com/cncf/tag-app-delivery
+      exclude:
+        - clomonitor
+- name: cncf-tag-network
+  display_name: TAG Network
+  description: CNCF Technical Advisory Group for Network
+  logo_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-network/icon/color/tag-network_icon-color.svg
+  logo_dark_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-network/icon/white/tag-network_icon-white.svg
+  repositories:
+    - name: tag-network
+      url: https://github.com/cncf/tag-network
+      exclude:
+        - clomonitor
+- name: cncf-tag-runtime
+  display_name: TAG Runtime
+  description: CNCF Technical Advisory Group for Runtime
+  logo_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-runtime/icon/color/tag-runtime_icon-color.svg
+  logo_dark_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-runtime/icon/white/tag-runtime_icon-white.svg
+  repositories:
+    - name: tag-runtime
+      url: https://github.com/cncf/tag-runtime
+      exclude:
+        - clomonitor
+- name: cncf-tag-observability
+  display_name: TAG Observability
+  description: CNCF Technical Advisory Group for Observability
+  logo_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-observability/icon/color/tag-observability_icon-color.svg
+  logo_dark_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-observability/icon/white/tag-observability_icon-white.svg
+  repositories:
+    - name: tag-observability
+      url: https://github.com/cncf/tag-observability
+      exclude:
+        - clomonitor
+- name: cncf-tag-env-sustainability
+  display_name: TAG Environmental Sustainability
+  description: CNCF Technical Advisory Group for Environmental Sustainability
+  logo_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-environmental-sustainability/color/tag-environmental-sustainability_color.svg
+  logo_dark_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-environmental-sustainability/white/tag-environmental-sustainability_white.svg
+  repositories:
+    - name: tag-env-sustainability
+      url: https://github.com/cncf/tag-env-sustainability
+      exclude:
+        - clomonitor

--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -2974,3 +2974,17 @@
       check_sets:
         - community
         - code
+- name: cncf-tag-contributor-strategy
+  display_name: TAG Contributor Strategy
+  description: CNCF Technical Advisory Group on Contributor Strategy -- maintainer relations, building up contributors, governance, graduation, and more.
+  logo_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-contributor-strategy/icon/color/tag-contributor-strategy-icon-color.svg
+  logo_dark_url: https://raw.githubusercontent.com/cncf/artwork/master/other/tag-contributor-strategy/icon/white/tag-contributor-strategy-icon-white.svg
+  repositories:
+    - name: tag-contributor-strategy
+      url: https://github.com/cncf/tag-contributor-strategy
+      exclude:
+        - clomonitor
+    - name: mentoring-wg
+      url: https://github.com/cncf/mentoring
+      exclude:
+        - clomonitor

--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -2988,3 +2988,13 @@
       url: https://github.com/cncf/mentoring
       exclude:
         - clomonitor
+- name: cncf-tag-security
+  display_name: TAG Security
+  description: CNCF Security Technical Advisory Group -- secure access, policy control, privacy, auditing, explainability and more!
+  logo_url: https://raw.githubusercontent.com/cncf/artwork/master/other/sig-security/icon/color/sig-security-icon-color.svg
+  logo_dark_url: https://raw.githubusercontent.com/cncf/artwork/master/other/sig-security/icon/white/sig-security-icon-white.svg
+  repositories:
+    - name: tag-security
+      url: https://github.com/cncf/tag-security
+      exclude:
+        - clomonitor


### PR DESCRIPTION
- Add CNCF tags to [CLOTributor](https://clotributor.dev/), so that `help wanted` issues are shown there
- TAGs won't show up in [CLOMonitor](https://clomonitor.io/search?page=1) though