### PR TITLE
Extend the community meeting check

### DIFF
--- a/clomonitor-core/src/linter/checks/community_meeting.rs
+++ b/clomonitor-core/src/linter/checks/community_meeting.rs
@@ -20,7 +20,7 @@ lazy_static! {
     #[rustfmt::skip]
     static ref README_REF: RegexSet = RegexSet::new([
         r"(?im)^#+.*meeting.*$",
-        r"(?i)(community|developer|development) \[?(call|event|meeting|session)",
+        r"(?i)(community|developer|development|working group) \[?(call|event|meeting|session)",
         r"(?i)(weekly|biweekly|monthly) \[?meeting",
         r"(?i)meeting minutes",
     ]).expect("exprs in README_REF to be valid");
@@ -50,5 +50,6 @@ mod tests {
         assert!(README_REF.is_match("community session"));
         assert!(README_REF.is_match("the meeting minutes below"));
         assert!(README_REF.is_match("Weekly meeting"));
+        assert!(README_REF.is_match("Working group meeting"));
     }
 }

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -414,7 +414,8 @@ This check passes if:
 - A *reference* to the community meeting is found in the repository's `README` file. Regexps used:
 
 ```sh
-"(?i)(community|developer|development) \[?(call|event|meeting|session)"
+"(?im)^#+.*meeting.*$"
+"(?i)(community|developer|development|working group) \[?(call|event|meeting|session)"
 "(?i)(weekly|biweekly|monthly) \[?meeting"
 "(?i)meeting minutes"
 ```


### PR DESCRIPTION
Add the "working group" string to the options for the community meeting check and update the check docs accordingly.