### PR TITLE
Notary: disable checks for inactive repo

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -1734,7 +1734,6 @@
     - name: notation
       url: https://github.com/notaryproject/notation
       check_sets:
-        - code-lite
         - community
         - code
 - name: ocm

--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -1735,9 +1735,6 @@
       url: https://github.com/notaryproject/notation
       check_sets:
         - code-lite
-    - name: notary
-      url: https://github.com/notaryproject/notary
-      check_sets:
         - community
         - code
 - name: ocm


### PR DESCRIPTION
As mentioned [here](https://github.com/notaryproject/notary/issues/1697#issuecomment-1824499424), it makes sense to enable all checks to run on [notaryproject/notation](https://github.com/notaryproject/notation) as this is the most active and up-to-date repository for the notary project.

Origin issue: https://github.com/cncf/techdocs/issues/196