### PR TITLE
Add more Devfile repos to monitor

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -527,6 +527,30 @@
       url: https://github.com/devfile/api
       check_sets:
         - code
+    - name: registry-operator
+      url: https://github.com/devfile/registry-operator
+      check_sets:
+        - code
+    - name: registry-support
+      url: https://github.com/devfile/registry-support
+      check_sets:
+        - code
+    - name: devfile-web
+      url: https://github.com/devfile/devfile-web
+      check_sets:
+        - code
+    - name: alizer
+      url: https://github.com/devfile/alizer
+      check_sets:
+        - code
+    - name: devworkspace-operator
+      url: https://github.com/devfile/devworkspace-operator
+      check_sets:
+        - code 
+    - name: developer-images
+      url: https://github.com/devfile/developer-images
+      check_sets:
+        - code-lite
 - name: devstream
   display_name: DevStream
   description: "DevStream: the open-source DevOps toolchain manager (DTM)"

--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -522,7 +522,7 @@
     - name: library
       url: https://github.com/devfile/library
       check_sets:
-        - code-lite
+        - code
     - name: api
       url: https://github.com/devfile/api
       check_sets:


### PR DESCRIPTION
As part of an effort to monitor our adherence to best practices more effectively we are looking to add more of our repositories to the CLO Monitor.