### PR TITLE
Chore: update community url for carvel

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -2816,7 +2816,7 @@
   maturity: sandbox
   repositories:
     - name: carvel
-      url: https://github.com/vmware-tanzu/carvel
+      url: https://github.com/carvel-dev/carvel
       check_sets:
         - community
     - name: carvel-kapp


### PR DESCRIPTION
As discussed [here](https://github.com/cncf/techdocs/issues/196#:~:text=so%20the%20solution%20would%20be%20to%20update%20it%20in%20the%20data%20file.), this PR updates the URL for the community checkset in Clomonitor.