### PR TITLE
Update repository URL for Keptn

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -1050,7 +1050,7 @@
         - code
 - name: keptn
   display_name: Keptn
-  description: Cloud-native application life-cycle orchestration. Keptn automates your SLO-driven multi-stage delivery and operations & remediation of your applications
+  description: Cloud-native application life-cycle orchestration. Keptn automates your SLO-driven multi-stage delivery and operations & remediation of your applications.
   category: app definition
   logo_url: https://raw.githubusercontent.com/cncf/artwork/master/projects/keptn/icon/color/keptn-icon-color.svg
   devstats_url: https://keptn.devstats.cncf.io/
@@ -1058,7 +1058,7 @@
   maturity: incubating
   repositories:
     - name: keptn
-      url: https://github.com/keptn/keptn
+      url: https://github.com/keptn/lifecycle-toolkit
       check_sets:
         - community
         - code


### PR DESCRIPTION
The default repo for the Keptn CNCF project was updated and this PR changes it for CLO Monitor to have accurate data in the repo readme.