### PR TITLE
Add Kubeflow subprojects in CLOMonitor

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -3389,6 +3389,14 @@
       url: https://github.com/kubeflow/pipelines
       check_sets:
         - code-lite
+    - name: training operator
+      url: https://github.com/kubeflow/training-operator
+      check-sets:
+        - code-lite
+    - name: katib
+      url: https://github.com/kubeflow/katib
+      check_sets:
+        - code-lite
     - name: community
       url: https://github.com/kubeflow/community
       check_sets:


### PR DESCRIPTION
Add CNCF Kubeflow subprojects [Kubeflow Training Operator](https://github.com/kubeflow/training-operator) and [Katib](https://github.com/kubeflow/katib) in [Kubeflow CLOMonitor](https://clomonitor.io/projects/cncf/kubeflow) to ensure they meet certain project health best practices

cc @andreyvelich @johnugeorge  @tenzen-y