### PR TITLE
Fix Kubeflow sub-project check

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -3389,7 +3389,7 @@
       url: https://github.com/kubeflow/pipelines
       check_sets:
         - code-lite
-    - name: training operator
+    - name: training-operator
       url: https://github.com/kubeflow/training-operator
       check-sets:
         - code-lite


### PR DESCRIPTION
Fix Training operator sub-project not showing up under Kubeflow repositories in [CLOMonitor](https://clomonitor.io/projects/cncf/kubeflow)