### PR TITLE
Add more Karmada repos to config

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -1000,8 +1000,15 @@
     - name: karmada
       url: https://github.com/karmada-io/karmada
       check_sets:
-        - community
         - code
+    - name: community
+      url: https://github.com/karmada-io/community
+      check_sets:
+        - community
+    - name: website
+      url: https://github.com/karmada-io/website
+      check_sets:
+        - docs
 - name: karpenter
   display_name: Karpenter
   description: Karpenter is a Kubernetes Node Autoscaler built for flexibility, performance, and simplicity.


### PR DESCRIPTION
Alongside repo `karmada`, we have other key repositories: `community` and `website`. 
- Repo `community` contains rich community content such as community meeting arrangements and how to become a contributor, etc. 
- Repo `website` contains the source code of [Karmada website](https://karmada.io/) and all of the docs for Karmada, providing a wealth of features, installation tutorials, usage tutorials, best practices and more! 

We hope to add these repos to CLOMonitor.