### PR TITLE
updating Backstage check_sets to include docs

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -124,6 +124,7 @@
       check_sets:
         - community
         - code
+        - docs
 - name: bfe
   display_name: Beyond Front End
   description: Open-source layer 7 load balancer derived from proprietary Baidu FrontEnd


### PR DESCRIPTION
Backstage has a monorepo (ish) so their docs are in their main repo.