### PR TITLE
Update cncf.yaml - Score update

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -4252,8 +4252,8 @@
       url: https://github.com/score-spec/score-compose
       check_sets:
         - code-lite
-    - name: score-helm
-      url: https://github.com/score-spec/score-helm
+    - name: score-k8s
+      url: https://github.com/score-spec/score-k8s
       check_sets:
         - code-lite
 - name: hami


### PR DESCRIPTION
Complementary to https://github.com/cncf/clomonitor/pull/1585, updating from `score-helm` (deprecated) to new `score-k8s` implementation.

@cynthia-sg , out of curiosity, is that correct to manually update this repo here? Or that's coming from an another source that we need to change there too?