### PR TITLE
Update cncf.yaml - Fix typo in Score's website repo

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -4267,9 +4267,10 @@
         - code-lite
         - community
     - name: website
-      url: https://github.com/score-spec/docs
+      url: https://github.com/score-spec/score.dev
       check_sets:
         - docs
+        - code-lite
         - community
 - name: hami
   display_name: HAMi


### PR DESCRIPTION
Sorry about that but with the previous one https://github.com/cncf/clomonitor/pull/1602 I made a typo, fixing Score's website repo now. Thanks!