### PR TITLE
Fix recommended security template link

### DIFF
--- a/web/src/layout/detail/repositories/__snapshots__/index.test.tsx.snap
+++ b/web/src/layout/detail/repositories/__snapshots__/index.test.tsx.snap
@@ -3645,7 +3645,7 @@ exports[`RepositoriesList creates snapshot 1`] = `
                     <a
                       aria-label="Recommended template: SECURITY.md"
                       class="link d-inline-block"
-                      href="https://github.com/cncf/tag-security/blob/main/project-resources/templates/SECURITY.md"
+                      href="https://github.com/cncf/tag-security/blob/main/community/resources/project-resources/templates/SECURITY.md"
                       rel="noopener noreferrer"
                       tabindex="-1"
                       target="_blank"

--- a/web/src/layout/detail/repositories/index.tsx
+++ b/web/src/layout/detail/repositories/index.tsx
@@ -223,7 +223,7 @@ const RepositoriesList = (props: Props) => {
                     recommendedTemplates={[
                       {
                         name: 'SECURITY.md',
-                        url: 'https://github.com/cncf/tag-security/blob/main/project-resources/templates/SECURITY.md',
+                        url: 'https://github.com/cncf/tag-security/blob/main/community/resources/project-resources/templates/SECURITY.md',
                       },
                     ]}
                     getAnchorLink={getAnchorLink}


### PR DESCRIPTION
Fix for link to the recommended security template

- [X] Commits are signed with Developer Certificate of Origin