### PR TITLE
Remove annual review templates

### DIFF
--- a/clomonitor-notifier/templates/annual-review-due-reminder.md
+++ b/clomonitor-notifier/templates/annual-review-due-reminder.md
@@ -1,5 +1,0 @@
-## Annual review due reminder
-
-This is a friendly reminder to let you know that your annual review is still due.
-
-For more information about how to file your annual review please see the [Sandbox annual review documentation](https://github.com/cncf/toc/blob/main/process/sandbox-annual-review.md#how-to-file-your-annual-review).

--- a/clomonitor-notifier/templates/annual-review-due.md
+++ b/clomonitor-notifier/templates/annual-review-due.md
@@ -1,7 +1,0 @@
-## Annual review due
-
-**Sandbox** projects are subject to an *annual review* by the **TOC**. This is intended to be a lightweight process to ensure that projects are on track, and getting the support they need.
-
-[CLOMonitor](https://clomonitor.io) has detected that the annual review for this project has not been filed yet. CLOMonitor relies on the information in the `annual_review_url` and `annual_review_date` fields in the [CNCF Landscape configuration file](https://github.com/cncf/landscape/blob/master/landscape.yml) for this check. If your annual review has already been presented, please make sure this information has been correctly added.
-
-For more information about how to file your annual review please see the [Sandbox annual review documentation](https://github.com/cncf/toc/blob/main/process/sandbox-annual-review.md#how-to-file-your-annual-review).


### PR DESCRIPTION
Removing annual review templates as projects are no longer required to submit annual reviews

xref: https://github.com/cncf/toc/issues/1404