### PR TITLE
Update docs OpenSSF Scorecard badge with new regexps

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -479,10 +479,16 @@ Scorecard assesses open source projects for security risks through a series of a
 
 This check passes if:
 
-- An `OpenSSF` Scorecard badge is found in the repository's `README` file. Regexps used:
+- An `OpenSSF` Scorecard badge is found in the repository's `README` file. Regexps used (old):
 
 ```sh
 "(https://api.securityscorecards.dev/projects/github.com/[^/]+/[^/]+)/badge"
+```
+
+- An `OpenSSF` Scorecard badge is found in the repository's `README` file. Regexps used (new):
+
+```sh
+"(https://api.scorecard.dev/projects/github.com/[^/]+/[^/]+)/badge"
 ```
 
 ### Recent release


### PR DESCRIPTION
Add new url to the documentation which was added via PR #1561 .

I also want to make a clear distinction between the old URL and the new URL. This ensures that people reading the documentation choose to use the new URL, but that it is also clear that the old URL is still supported.

- [X] Commits are signed with Developer Certificate of Origin (DCO)