### PR TITLE
Change opentelemetry-java-examples repo to code-lite

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -1966,7 +1966,7 @@
     - name: opentelemetry-java-examples
       url: https://github.com/open-telemetry/opentelemetry-java-examples
       check_sets:
-        - code
+        - code-lite
     - name: opentelemetry-java-instrumentation
       url: https://github.com/open-telemetry/opentelemetry-java-instrumentation
       check_sets:


### PR DESCRIPTION
This repo better fits the description (and requirements) of code-lite as it only contains example code.