### PR TITLE
Set OpenTelemetry Java examples as a docs repo

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -1966,7 +1966,7 @@
     - name: opentelemetry-java-examples
       url: https://github.com/open-telemetry/opentelemetry-java-examples
       check_sets:
-        - code-lite
+        - docs
     - name: opentelemetry-java-instrumentation
       url: https://github.com/open-telemetry/opentelemetry-java-instrumentation
       check_sets:


### PR DESCRIPTION
this repo doesn't publish any releases or artifacts