### PR TITLE
Label opentelemetry-proto repo as docs

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -2006,7 +2006,7 @@
     - name: opentelemetry-proto
       url: https://github.com/open-telemetry/opentelemetry-proto
       check_sets:
-        - code
+        - docs
     - name: opentelemetry-proto-java
       url: https://github.com/open-telemetry/opentelemetry-proto-java
       check_sets:


### PR DESCRIPTION
same as the other OpenTelemetry specification repos