### PR TITLE
Add oscal-sdk-go and compliance-to-policy-go repositories

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -4181,6 +4181,16 @@
       url: https://github.com/oscal-compass/compliance-trestle-demos
       check_sets:
         - code-lite
+    - name: oscal-sdk-go
+      url: https://github.com/oscal-compass/oscal-sdk-go
+      check_sets:
+        - code-lite
+    - name: compliance-to-policy-go
+      url: https://github.com/oscal-compass/compliance-to-policy
+      check_sets:
+        - code-lite
+
+
 - name: perses
   display_name: Perses
   description: Perses is a dashboard tool to visualize observability data from Prometheus/Thanos/Jaeger

--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -4186,7 +4186,7 @@
       check_sets:
         - code-lite
     - name: compliance-to-policy-go
-      url: https://github.com/oscal-compass/compliance-to-policy
+      url: https://github.com/oscal-compass/compliance-to-policy-go
       check_sets:
         - code-lite
 


### PR DESCRIPTION
Hi all,
I'm trying to fix https://github.com/oscal-compass/community/issues/96

I have added 2 new repositories following the format that was used by other PR

Happy to work on it if I missed anything

