### PR TITLE
test: add unit testing for security insights v1

### DIFF
--- a/clomonitor-core/src/testdata/security-insights-v1/SECURITY-INSIGHTS.yml
+++ b/clomonitor-core/src/testdata/security-insights-v1/SECURITY-INSIGHTS.yml
@@ -1,0 +1,49 @@
+header:
+  schema-version: 1.0.0
+  last-updated: '2023-09-28'
+  last-reviewed: '2023-09-28'
+  expiration-date: '2024-09-28T01:00:00.000Z'
+  project-url: https://github.com/ossf/security-insights-spec
+  project-release: '1.0.0'
+project-lifecycle:
+  status: active
+  bug-fixes-only: false
+  core-maintainers:
+  - github:luigigubello
+  - github:eddie-knight
+contribution-policy:
+  accepts-pull-requests: true
+  accepts-automated-pull-requests: true
+  code-of-conduct: https://openssf.org/community/code-of-conduct
+documentation:
+- https://github.com/ossf/security-insights-spec/blob/main/specification.md
+distribution-points:
+- https://github.com/ossf/security-insights-spec
+security-artifacts:
+  threat-model:
+    threat-model-created: true
+    evidence-url:
+    - https://github.com/ossf/security-insights-spec/blob/main/docs/threat-model.md
+security-testing:
+- tool-type: sca
+  tool-name: Dependabot
+  tool-version: latest
+  integration:
+    ad-hoc: false
+    ci: true
+    before-release: true
+  comment: |
+    Dependabot is enabled for this repo.
+security-contacts:
+- type: email
+  value: security@openssf.org
+vulnerability-reporting:
+  accepts-vulnerability-reports: true
+  security-policy: https://github.com/ossf/security-insights-spec/security/policy
+  email-contact: security@openssf.org
+  comment: |
+    The first and best way to report a vulnerability is by using private security issues in GitHub.
+dependencies:
+  third-party-packages: true
+  dependencies-lists:
+  - https://github.com/ossf/security-insights-spec/blob/main/validators/python/requirements.txt

--- a/clomonitor-core/src/testdata/security-insights-v1/invalid/SECURITY-INSIGHTS.yml
+++ b/clomonitor-core/src/testdata/security-insights-v1/invalid/SECURITY-INSIGHTS.yml
@@ -1,0 +1,13 @@
+header:
+  schema-version: 1.0.0
+  last-updated: '2023-09-28'
+  last-reviewed: '2023-09-28'
+  expiration-date: '2024-09-28T01:00:00.000Z'
+  project-release: '1.0.0'
+project-lifecycle:
+  stage: active
+  bug-fixes-only: false
+contribution-policy:
+  accepts-pull-requests: true
+  accepts-automated-pull-requests: true
+  code-of-conduct: https://openssf.org/community/code-of-conduct


### PR DESCRIPTION
This change adds 3 test cases to validate the behavior of `SecurityInsights#new` in the following circumstances:

 * Returns `None` when no file is found
 * Returns error when file found is invalid
 * Returns properly deserialized data when a valid yml is found