### PR TITLE
Move KServe fromLF AI and Data to CNCF

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -1386,7 +1386,7 @@
         - code
 - name: kserve
   display_name: KServe
-  description: Serverless Inferencing on Kubernetes
+  description: Standardized Distributed Generative and Predictive AI Inference Platform for Scalable, Multi-Framework Deployment on Kubernetes
   category: model
   logo_url: https://raw.githubusercontent.com/cncf/artwork/main/projects/kserve/icon/color/k-serve-icon-color.svg
   accepted_at: "2025-09-28"

--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -1400,7 +1400,7 @@
       url: https://github.com/kserve/modelmesh-serving
       check_sets:
         - code-lite
-    - name: kserve
+    - name: community
       url: https://github.com/kserve/community
       check_sets:
         - community

--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -1384,6 +1384,23 @@
       check_sets:
         - community
         - code
+- name: kserve
+  display_name: KServe
+  description: Serverless Inferencing on Kubernetes
+  category: model
+  logo_url: https://raw.githubusercontent.com/cncf/artwork/main/projects/kserve/icon/color/k-serve-icon-color.svg
+  accepted_at: "2021-11-18"
+  maturity: incubating
+  repositories:
+    - name: kserve
+      url: https://github.com/kserve/kserve
+      check_sets:
+        - community
+        - code
+    - name: modelmesh-serving
+      url: https://github.com/kserve/modelmesh-serving
+      check_sets:
+        - code-lite
 - name: kube-state-metrics
   display_name: Kube State Metrics
   description: Add-on agent to generate and expose cluster-level metrics

--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -1389,18 +1389,21 @@
   description: Serverless Inferencing on Kubernetes
   category: model
   logo_url: https://raw.githubusercontent.com/cncf/artwork/main/projects/kserve/icon/color/k-serve-icon-color.svg
-  accepted_at: "2021-11-18"
+  accepted_at: "2025-09-28"
   maturity: incubating
   repositories:
     - name: kserve
       url: https://github.com/kserve/kserve
       check_sets:
-        - community
         - code
     - name: modelmesh-serving
       url: https://github.com/kserve/modelmesh-serving
       check_sets:
         - code-lite
+    - name: kserve
+      url: https://github.com/kserve/community
+      check_sets:
+        - community
 - name: kube-state-metrics
   display_name: Kube State Metrics
   description: Add-on agent to generate and expose cluster-level metrics

--- a/data/lfaidata.yaml
+++ b/data/lfaidata.yaml
@@ -304,23 +304,6 @@
       check_sets:
         - community
         - code
-- name: kserve
-  display_name: KServe
-  description: Serverless Inferencing on Kubernetes
-  category: model
-  logo_url: https://raw.githubusercontent.com/lfai/artwork/main/projects/kserve/icon/color/k-serve-icon-color.svg
-  accepted_at: "2021-11-18"
-  maturity: incubating
-  repositories:
-    - name: kserve
-      url: https://github.com/kserve/kserve
-      check_sets:
-        - community
-        - code
-    - name: modelmesh-serving
-      url: https://github.com/kserve/modelmesh-serving
-      check_sets:
-        - code-lite
 - name: ludwig
   display_name: Ludwig
   description: Ludwig is a toolbox that allows to train and evaluate deep learning models without the need to write code


### PR DESCRIPTION
### Project added to CNCF Issue
https://github.com/cncf/toc/issues/1905


The project artwork logo url is dependent on the merge of the CNCF artwork PR
https://github.com/cncf/artwork/pull/593
