### PR TITLE
Update Kubewarden repositories in CNCF

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -1526,20 +1526,8 @@
       url: https://github.com/kubewarden/kubewarden.io
       check_sets:
         - docs
-    - name: policy-server
-      url: https://github.com/kubewarden/policy-server
-      check_sets:
-        - code
-    - name: kubewarden-controller
-      url: https://github.com/kubewarden/kubewarden-controller
-      check_sets:
-        - code
-    - name: kwctl
-      url: https://github.com/kubewarden/kwctl
-      check_sets:
-        - code
-    - name: audit-scanner
-      url: https://github.com/kubewarden/audit-scanner
+    - name: adm-controller
+      url: https://github.com/kubewarden/adm-controller
       check_sets:
         - code
 - name: kudo


### PR DESCRIPTION
Recently, the Kubewarden project unified its major components into a single repository (kubewarden/adm-controller). And the old repositories have been archived. Therefore, this commit updates the repositories that CLOMonitor should verify to the new monorepo. Removing the individual components repositories.

Part of https://github.com/kubewarden/adm-controller/issues/1665