### PR TITLE
ci: pin contents: read on build-images and ci

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -12,6 +12,11 @@ env:
   OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
   OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
 
+# OCIR push uses OCI_AUTH_TOKEN + OCI_CLI_* secrets; default GITHUB_TOKEN
+# only needs read for the checkout.
+permissions:
+  contents: read
+
 jobs:
   build-dbmigrator-image:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   linter-backend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for the two workflows still inheriting org defaults:

- `build-images.yml` — multi-image build for dbmigrator/registrar/tracker/etc. OCIR push authenticates via `OCI_AUTH_TOKEN` + `OCI_CLI_*` secrets.
- `ci.yml` — clippy/rustfmt/test matrix; no API writes.

YAML validated locally.