### PR TITLE
Update tekton devstats url

### DIFF
--- a/data/cncf.yaml
+++ b/data/cncf.yaml
@@ -5161,7 +5161,7 @@
   category: app definition
   logo_url: https://raw.githubusercontent.com/cncf/artwork/main/projects/tekton/icon/color/tekton-icon-color.svg
   logo_dark_url: https://raw.githubusercontent.com/cncf/artwork/main/projects/tekton/icon/white/tekton-icon-white.svg
-  devstats_url: https://tekton.devstats.cd.foundation
+  devstats_url: https://tekton.devstats.cncf.io
   maturity: incubating
   repositories:
     - name: community


### PR DESCRIPTION
Pending https://github.com/cncf/devstats/issues/141, this PR aims to update Tektons CLOMonitor references to point to the updated devstats URL.